### PR TITLE
fix: add missing routes in provider paths to fix ACTION_VIEW intent

### DIFF
--- a/TMessagesProj/src/main/res/xml/provider_paths.xml
+++ b/TMessagesProj/src/main/res/xml/provider_paths.xml
@@ -8,6 +8,13 @@
     <files-path
         name="files-media"
         path="media/" />
+    <cache-path name="cache_root" path="." />
+    <files-path name="files_root" path="." />
+    <external-path name="external_root" path="." />
+    <external-cache-path name="external_cache_root" path="." />
+    <external-files-path name="external_files_root" path="." />
+    <external-media-path name="external_media_root" path="." />
+    <root-path name="root" path="." />
     <files-path name="logs" path="/logs/"/>
     <files-path name="cache" path="/cache/"/>
     <root-path name="external_files" path="/storage/" />


### PR DESCRIPTION
This fixes the issue where downloaded files inside Nagram X (like `.txt`, `.pdf`, `.apk`) showed a "No applications can handle the file type" error instead of opening or triggering the intent app chooser. 

The Android `FileProvider` was lacking proper definitions for external and local paths, causing an `IllegalArgumentException` out of bounds when selecting a downloaded file's path. Since the app failed parsing the path, it dropped into the catch-all scope making the system mistakenly believe no viewer app was present. I added total coverage of `<root-path>`, `<cache-path>`, etc to resolve validation paths inside `provider_paths.xml` definitions. 

Fixes #285 