### PR TITLE
feat(share): add forward options and folder tabs to share popup

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/FilterTabsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/FilterTabsView.java
@@ -1337,6 +1337,20 @@ public class FilterTabsView extends FrameLayout {
         scrollToTab(tabs.get(tabs.size() - 1), tabs.size() - 1);
     }
 
+    public void selectPrevTab() {
+        if (tabs.isEmpty() || currentPosition <= 0) {
+            return;
+        }
+        scrollToTab(tabs.get(currentPosition - 1), currentPosition - 1);
+    }
+
+    public void selectNextTab() {
+        if (tabs.isEmpty() || currentPosition >= tabs.size() - 1) {
+            return;
+        }
+        scrollToTab(tabs.get(currentPosition + 1), currentPosition + 1);
+    }
+
     public void setAnimationIdicatorProgress(float value) {
         animatingIndicatorProgress = value;
         listView.invalidateViews();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ShareAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ShareAlert.java
@@ -140,6 +140,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import tw.nekomimi.nekogram.NekoConfig;
 import xyz.nextalone.nagram.NaConfig;
+import org.telegram.ui.Components.FilterTabsView;
 
 public class ShareAlert extends BottomSheet implements NotificationCenter.NotificationCenterDelegate {
 
@@ -230,9 +231,94 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
     private LongSparseArray<DialogsSearchAdapter.RecentSearchObject> recentSearchObjectsById = new LongSparseArray<>();
     TL_stories.StoryItem storyItem;
 
+    private FilterTabsView filterTabsView;
+    private int currentFilterId = 0;
+    private int maxDialogsCount = 0;
+
+    private LinearLayout toggleContainer;
+    private ImageView toggleAuthorButton;
+    private ImageView toggleCaptionButton;
+    private ImageView toggleNotifyButton;
+
+    private android.view.GestureDetector swipeGestureDetector;
+    private static final int SWIPE_THRESHOLD = 100;
+    private static final int SWIPE_VELOCITY_THRESHOLD = 100;
+
     public void setStoryToShare(TL_stories.StoryItem storyItem) {
         this.storyItem = storyItem;
     }
+
+    private boolean isForwardNotifyEffective() {
+        if (NaConfig.INSTANCE.getSilentMessageByDefault().Bool()) {
+            return false; // Ghost mode overrides to silent
+        }
+        return NaConfig.INSTANCE.getForwardNotify().Bool();
+    }
+
+    private ImageView createToggleButton(int iconRes, int index) {
+        ImageView button = new ImageView(getContext());
+        button.setImageResource(iconRes);
+        button.setScaleType(ImageView.ScaleType.CENTER);
+        button.setPadding(AndroidUtilities.dp(4), AndroidUtilities.dp(4), AndroidUtilities.dp(4), AndroidUtilities.dp(4));
+        button.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_listSelector), 1));
+        button.setOnClickListener(v -> toggleOption(index));
+        return button;
+    }
+
+    private void toggleOption(int index) {
+        if (index == 0) { // Author (quote)
+            boolean newValue = !NaConfig.INSTANCE.getForwardHideSenderName().Bool();
+            NaConfig.INSTANCE.getForwardHideSenderName().setConfigBool(newValue);
+            updateToggleIcon(toggleAuthorButton, 0, !newValue);
+            // When enabling quote (show author), enable caption too
+            if (!newValue && NaConfig.INSTANCE.getForwardHideCaption().Bool()) {
+                NaConfig.INSTANCE.getForwardHideCaption().setConfigBool(false);
+                updateToggleIcon(toggleCaptionButton, 1, true);
+            }
+        } else if (index == 1) { // Caption
+            boolean newValue = !NaConfig.INSTANCE.getForwardHideCaption().Bool();
+            NaConfig.INSTANCE.getForwardHideCaption().setConfigBool(newValue);
+            updateToggleIcon(toggleCaptionButton, 1, !newValue);
+            // When disabling caption, disable quote (hide author) too
+            if (newValue && !NaConfig.INSTANCE.getForwardHideSenderName().Bool()) {
+                NaConfig.INSTANCE.getForwardHideSenderName().setConfigBool(true);
+                updateToggleIcon(toggleAuthorButton, 0, false);
+            }
+        } else if (index == 2) { // Sound
+            if (NaConfig.INSTANCE.getSilentMessageByDefault().Bool()) {
+                Toast.makeText(getContext(), LocaleController.getString(R.string.GhostModeSoundOverride), Toast.LENGTH_SHORT).show();
+                return;
+            }
+            boolean newValue = !NaConfig.INSTANCE.getForwardNotify().Bool();
+            NaConfig.INSTANCE.getForwardNotify().setConfigBool(newValue);
+            updateToggleIcon(toggleNotifyButton, 2, newValue);
+        }
+    }
+
+    private void updateToggleIcon(ImageView button, int index, boolean active) {
+        int activeColor = getThemedColor(Theme.key_dialogTextBlue);
+        int inactiveColor = getThemedColor(Theme.key_dialogTextGray2);
+        button.setColorFilter(active ? activeColor : inactiveColor);
+
+        if (index == 2) {
+            boolean ghostModeActive = NaConfig.INSTANCE.getSilentMessageByDefault().Bool();
+            button.setAlpha(ghostModeActive ? 0.4f : 1.0f);
+            button.setImageResource(active ? R.drawable.input_notify_on : R.drawable.input_notify_off);
+        }
+    }
+
+    private void updateAllToggleIcons() {
+        if (toggleAuthorButton != null) {
+            updateToggleIcon(toggleAuthorButton, 0, !NaConfig.INSTANCE.getForwardHideSenderName().Bool());
+        }
+        if (toggleCaptionButton != null) {
+            updateToggleIcon(toggleCaptionButton, 1, !NaConfig.INSTANCE.getForwardHideCaption().Bool());
+        }
+        if (toggleNotifyButton != null) {
+            updateToggleIcon(toggleNotifyButton, 2, isForwardNotifyEffective());
+        }
+    }
+
 
     public interface ShareAlertDelegate {
         default void didShare() {
@@ -700,8 +786,9 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
                 }
                 int availableHeight = totalHeight - getPaddingTop();
 
-                int size = Math.max(searchAdapter.getItemCount(), listAdapter.getItemCount() - 1);
-                int contentSize = dp(103) + dp(48) + Math.max(2, (int) Math.ceil(size / 4.0f)) * dp(103) + backgroundPaddingTop;
+                int size = Math.max(searchAdapter.getItemCount(), maxDialogsCount > 0 ? maxDialogsCount : listAdapter.getItemCount() - 1);
+                int filterTabsHeight = (filterTabsView != null && filterTabsView.getVisibility() == View.VISIBLE) ? dp(44) : 0;
+                int contentSize = dp(103) + dp(48) + filterTabsHeight + Math.max(2, (int) Math.ceil(size / 4.0f)) * dp(103) + backgroundPaddingTop;
                 if (topicsGridView.getVisibility() != View.GONE) {
                     int topicsSize = dp(103) + dp(48) + Math.max(2, (int) Math.ceil((shareTopicsAdapter.getItemCount() - 1) / 4.0f)) * dp(103) + backgroundPaddingTop;
                     if (topicsSize > contentSize) {
@@ -1081,6 +1168,94 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
         });
 
         frameLayout.addView(searchView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 40, Gravity.BOTTOM | Gravity.LEFT, 11, 7, 11, 11));
+
+        // Toggle buttons container
+        toggleContainer = new LinearLayout(context);
+        toggleContainer.setOrientation(LinearLayout.HORIZONTAL);
+        toggleContainer.setGravity(Gravity.CENTER_VERTICAL);
+        toggleContainer.setPadding(dp(4), 0, dp(4), 0);
+
+        int toggleSize = AndroidUtilities.dp(28);
+
+        toggleAuthorButton = createToggleButton(R.drawable.msg_forward, 0);
+        toggleContainer.addView(toggleAuthorButton, new LinearLayout.LayoutParams(toggleSize, toggleSize));
+
+        toggleCaptionButton = createToggleButton(R.drawable.msg_stories_caption, 1);
+        toggleContainer.addView(toggleCaptionButton, new LinearLayout.LayoutParams(toggleSize, toggleSize));
+
+        toggleNotifyButton = createToggleButton(R.drawable.input_notify_on, 2);
+        toggleContainer.addView(toggleNotifyButton, new LinearLayout.LayoutParams(toggleSize, toggleSize));
+
+        frameLayout.addView(toggleContainer, LayoutHelper.createFrame(LayoutHelper.WRAP_CONTENT, 40, Gravity.BOTTOM | Gravity.RIGHT, 11, 7, 11, 11));
+
+        updateAllToggleIcons();
+
+        ArrayList<MessagesController.DialogFilter> filters = MessagesController.getInstance(currentAccount).getDialogFilters();
+        if (!filters.isEmpty()) {
+            filterTabsView = new FilterTabsView(context, resourcesProvider);
+            filterTabsView.setVisibility(filters.size() > 1 ? View.VISIBLE : View.GONE);
+
+            filterTabsView.setDelegate(new FilterTabsView.FilterTabsViewDelegate() {
+                @Override
+                public void onPageSelected(FilterTabsView.Tab tab, boolean forward) {
+                    currentFilterId = tab.id;
+                    if (listAdapter != null) {
+                        listAdapter.fetchDialogs();
+                        listAdapter.notifyDataSetChanged();
+                        gridView.scrollToPosition(0);
+                    }
+                }
+
+                @Override
+                public void onPageScrolled(float progress) {
+                }
+
+                @Override
+                public void onSamePageSelected() {
+                }
+
+                @Override
+                public int getTabCounter(int tabId) {
+                    return 0;
+                }
+
+                @Override
+                public boolean didSelectTab(FilterTabsView.TabView tabView, boolean selected) {
+                    return true;
+                }
+
+                @Override
+                public boolean isTabMenuVisible() {
+                    return false;
+                }
+
+                @Override
+                public void onDeletePressed(int id) {
+                }
+
+                @Override
+                public void onPageReorder(int fromId, int toId) {
+                }
+
+                @Override
+                public boolean canPerformActions() {
+                    return true;
+                }
+            });
+
+            filterTabsView.removeTabs();
+            for (int a = 0, N = filters.size(); a < N; a++) {
+                MessagesController.DialogFilter filter = filters.get(a);
+                if (filter.isDefault()) {
+                    if (filterTabsView.showAllChatsTab) {
+                        filterTabsView.addTab(0, 0, LocaleController.getString(R.string.FilterAllChats), filter.emoticon, null, false, true, filter.locked);
+                    }
+                } else {
+                    filterTabsView.addTab(filter.localId, filter.localId, filter.name, filter.emoticon, filter.entities, filter.title_noanimate, false, filter.locked);
+                }
+            }
+        }
+
         topicsBackActionBar = new ActionBar(context);
         topicsBackActionBar.setOccupyStatusBar(false);
         topicsBackActionBar.setBackButtonImage(R.drawable.ic_ab_back);
@@ -1157,14 +1332,16 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
 
             @Override
             protected boolean allowSelectChildAtPosition(float x, float y) {
-                return y >= dp(darkTheme && linkToCopy[1] != null ? 111 : 58) + AndroidUtilities.statusBarHeight;
+                int filterTabsHeight = (filterTabsView != null && filterTabsView.getVisibility() == View.VISIBLE) ? dp(44) : 0;
+                return y >= dp(darkTheme && linkToCopy[1] != null ? 111 : 58) + filterTabsHeight + AndroidUtilities.statusBarHeight;
             }
 
             @Override
             public void draw(Canvas canvas) {
                 if (topicsGridView.getVisibility() != View.GONE) {
+                    int filterTabsHeight = (filterTabsView != null && filterTabsView.getVisibility() == View.VISIBLE) ? dp(44) : 0;
                     canvas.save();
-                    canvas.clipRect(0, scrollOffsetY + dp(darkTheme && linkToCopy[1] != null ? 111 : 58), getWidth(), getHeight());
+                    canvas.clipRect(0, scrollOffsetY + dp(darkTheme && linkToCopy[1] != null ? 111 : 58) + filterTabsHeight, getWidth(), getHeight());
                 }
                 super.draw(canvas);
                 if (topicsGridView.getVisibility() != View.GONE) {
@@ -1185,6 +1362,9 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
             @Override
             public int getSpanSize(int position) {
                 if (position == 0) {
+                    return layoutManager.getSpanCount();
+                }
+                if (position == 1 && filterTabsView != null && filterTabsView.getVisibility() == View.VISIBLE) {
                     return layoutManager.getSpanCount();
                 }
                 return 1;
@@ -1235,6 +1415,32 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
                     blur3_InvalidateBlur();
                 }
             }
+        });
+
+        // Swipe gestures for folder switching
+        swipeGestureDetector = new android.view.GestureDetector(context, new android.view.GestureDetector.SimpleOnGestureListener() {
+            @Override
+            public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+                if (filterTabsView == null || filterTabsView.getVisibility() != View.VISIBLE) {
+                    return false;
+                }
+                float diffX = e2.getX() - e1.getX();
+                if (Math.abs(diffX) > SWIPE_THRESHOLD && Math.abs(velocityX) > SWIPE_VELOCITY_THRESHOLD) {
+                    if (diffX > 0) {
+                        filterTabsView.selectPrevTab();
+                    } else {
+                        filterTabsView.selectNextTab();
+                    }
+                    return true;
+                }
+                return false;
+            }
+        });
+        gridView.setOnTouchListener((v, event) -> {
+            if (swipeGestureDetector != null) {
+                swipeGestureDetector.onTouchEvent(event);
+            }
+            return false;
         });
 
         searchGridView = new RecyclerListView(context, resourcesProvider) {
@@ -1772,7 +1978,10 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
         writeButton.setCirclePadding(dp(1), dp(6));
         writeButton.newCounterPos = true;
         writeButtonContainer.addView(writeButton, LayoutHelper.createFrameMatchParent());
-        writeButton.setOnClickListener(v -> sendInternal(true));
+        writeButton.setOnClickListener(v -> {
+            showSendersName = !NaConfig.INSTANCE.getForwardHideSenderName().Bool();
+            sendInternal(isForwardNotifyEffective());
+        });
         writeButton.setOnLongClickListener(v -> onSendLongClick(writeButton));
 
         textPaint.setTextSize(dp(12));
@@ -2269,7 +2478,7 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
             }
             sendPopupLayout1.addView(showSendersNameView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48));
             showSendersNameView.setTextAndIcon(false ? LocaleController.getString(R.string.ShowSenderNames) : LocaleController.getString(R.string.ShowSendersName), 0);
-            showSendersNameView.setChecked(showSendersName = true);
+            showSendersNameView.setChecked(showSendersName = !NaConfig.INSTANCE.getForwardHideSenderName().Bool());
 
             ActionBarMenuSubItem hideSendersNameView = new ActionBarMenuSubItem(getContext(), true, false, true, resourcesProvider);
             if (darkTheme) {
@@ -2324,7 +2533,7 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
             sendWithoutSound.setTextColor(getThemedColor(Theme.key_voipgroup_nameText));
             sendWithoutSound.setIconColor(getThemedColor(Theme.key_windowBackgroundWhiteHintText));
         }
-        boolean sendWithoutSoundNax = NaConfig.INSTANCE.getSilentMessageByDefault().Bool();
+        boolean sendWithoutSoundNax = !isForwardNotifyEffective();
         sendWithoutSound.setTextAndIcon(sendWithoutSoundNax ? getString(R.string.SendWithSound) : getString(R.string.SendWithoutSound), sendWithoutSoundNax ? R.drawable.input_notify_on : R.drawable.input_notify_off);
         sendWithoutSound.setMinimumWidth(dp(196));
         sendPopupLayout2.addView(sendWithoutSound, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48));
@@ -2346,7 +2555,7 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
             if (sendPopupWindow != null && sendPopupWindow.isShowing()) {
                 sendPopupWindow.dismiss();
             }
-            sendInternal(true);
+            sendInternal(isForwardNotifyEffective());
         });
         sendPopupLayout2.setupRadialSelectors(getThemedColor(Theme.key_dialogButtonSelector));
 
@@ -2481,20 +2690,23 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
                         replyTopMsg.isTopicMainMessage = true;
                     }
                     int result = 0;
+                    boolean forwardHideSender = !showSendersName;
+                    boolean forwardHideCaption = NaConfig.INSTANCE.getForwardHideCaption().Bool();
+                    boolean forwardNotify = withSound;
                     if (NekoConfig.sendCommentAfterForward.Bool()) {
                         // send fwd message before comment.
-                        result = SendMessagesHelper.getInstance(currentAccount).sendMessage(sendingMessageObjects, key, !showSendersName,false, withSound, 0, replyTopMsg, video_timestamp, price == null ? 0 : price);
+                        result = SendMessagesHelper.getInstance(currentAccount).sendMessage(sendingMessageObjects, key, forwardHideSender, forwardHideCaption, forwardNotify, 0, replyTopMsg, video_timestamp, price == null ? 0 : price);
                     }
                     // send comment message
                     if (frameLayout2.getTag() != null && commentTextView.length() > 0) {
-                        SendMessagesHelper.SendMessageParams params = SendMessagesHelper.SendMessageParams.of(text[0] == null ? null : text[0].toString(), key, replyTopMsg, replyTopMsg, null, true, entities, null, null, withSound, 0, 0, null, false);
+                        SendMessagesHelper.SendMessageParams params = SendMessagesHelper.SendMessageParams.of(text[0] == null ? null : text[0].toString(), key, replyTopMsg, replyTopMsg, null, true, entities, null, null, forwardNotify, 0, 0, null, false);
                         params.payStars = price == null ? 0 : price;
                         params.monoForumPeer = monoForumPeerId;
                         SendMessagesHelper.getInstance(currentAccount).sendMessage(params);
                     }
                     if (!NekoConfig.sendCommentAfterForward.Bool()) {
                         // send fwd message after comment.
-                        result = SendMessagesHelper.getInstance(currentAccount).sendMessage(sendingMessageObjects, key, !showSendersName,false, withSound, 0, 0, replyTopMsg, video_timestamp, price == null ? 0 : price, monoForumPeerId, null);
+                        result = SendMessagesHelper.getInstance(currentAccount).sendMessage(sendingMessageObjects, key, forwardHideSender, forwardHideCaption, forwardNotify, 0, 0, replyTopMsg, video_timestamp, price == null ? 0 : price, monoForumPeerId, null);
                     }
                     if (result != 0) {
                         removeKeys.add(key);
@@ -2921,6 +3133,19 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
                 dialogs.add(dialog);
                 dialogsMap.put(dialog.id, dialog);
             }
+
+            // Get filter by currentFilterId
+            MessagesController.DialogFilter currentFilter = null;
+            if (currentFilterId > 0) {
+                ArrayList<MessagesController.DialogFilter> filters = MessagesController.getInstance(currentAccount).getDialogFilters();
+                for (MessagesController.DialogFilter filter : filters) {
+                    if (filter.localId == currentFilterId) {
+                        currentFilter = filter;
+                        break;
+                    }
+                }
+            }
+
             ArrayList<TLRPC.Dialog> archivedDialogs = new ArrayList<>();
             ArrayList<TLRPC.Dialog> allDialogs = MessagesController.getInstance(currentAccount).getAllDialogs();
             for (int a = 0; a < allDialogs.size(); a++) {
@@ -2932,6 +3157,10 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
                     continue;
                 }
                 if (!DialogObject.isEncryptedDialog(dialog.id)) {
+                    // Filter by folder
+                    if (currentFilter != null && !currentFilter.includesDialog(AccountInstance.getInstance(currentAccount), dialog.id)) {
+                        continue;
+                    }
                     if (DialogObject.isUserDialog(dialog.id)) {
                         if (dialog.folder_id == 1) {
                             archivedDialogs.add(dialog);
@@ -2967,6 +3196,7 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
                         break;
                 }
             }
+            maxDialogsCount = Math.max(maxDialogsCount, dialogs.size());
             notifyDataSetChanged();
         }
 
@@ -2974,13 +3204,20 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
         public int getItemCount() {
             int count = dialogs.size();
             if (count != 0) {
-                count++;
+                count++; // placeholder
+                if (filterTabsView != null && filterTabsView.getVisibility() == View.VISIBLE) {
+                    count++; // filterTabs
+                }
             }
             return count;
         }
 
         public TLRPC.Dialog getItem(int position) {
-            position--;
+            int offset = 1; // placeholder
+            if (filterTabsView != null && filterTabsView.getVisibility() == View.VISIBLE) {
+                offset = 2; // placeholder + filterTabs
+            }
+            position -= offset;
             if (position < 0 || position >= dialogs.size()) {
                 return null;
             }
@@ -2989,7 +3226,7 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
 
         @Override
         public boolean isEnabled(RecyclerView.ViewHolder holder) {
-            if (holder.getItemViewType() == 1) {
+            if (holder.getItemViewType() == 1 || holder.getItemViewType() == 2) {
                 return false;
             }
             return true;
@@ -3012,10 +3249,22 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
                     view.setLayoutParams(new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT, dp(100)));
                     break;
                 }
+                case 2: {
+                    // FilterTabsView wrapper
+                    FrameLayout wrapper = new FrameLayout(context);
+                    if (filterTabsView != null && filterTabsView.getParent() != null) {
+                        ((ViewGroup) filterTabsView.getParent()).removeView(filterTabsView);
+                    }
+                    wrapper.addView(filterTabsView, new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+                    wrapper.setLayoutParams(new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT, dp(44)));
+                    return new RecyclerListView.Holder(wrapper);
+                }
                 case 1:
                 default: {
                     view = new View(context);
-                    view.setLayoutParams(new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT, dp(darkTheme && linkToCopy[1] != null ? 109 : 56)));
+                    // Placeholder for space above chats
+                    int baseHeight = darkTheme && linkToCopy[1] != null ? 109 : 56;
+                    view.setLayoutParams(new RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT, dp(baseHeight)));
                     break;
                 }
             }
@@ -3037,9 +3286,12 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
         @Override
         public int getItemViewType(int position) {
             if (position == 0) {
-                return 1;
+                return 1; // placeholder
             }
-            return 0;
+            if (position == 1 && filterTabsView != null && filterTabsView.getVisibility() == View.VISIBLE) {
+                return 2; // filterTabs
+            }
+            return 0; // chat cell
         }
     }
 

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -897,6 +897,24 @@ object NaConfig {
             ConfigItem.configTypeBool,
             true
         )
+    val forwardHideSenderName =
+        addConfig(
+            "ForwardHideSenderName",
+            ConfigItem.configTypeBool,
+            false
+        )
+    val forwardHideCaption =
+        addConfig(
+            "ForwardHideCaption",
+            ConfigItem.configTypeBool,
+            false
+        )
+    val forwardNotify =
+        addConfig(
+            "ForwardNotify",
+            ConfigItem.configTypeBool,
+            true
+        )
     val dontAutoPlayNextVoice =
         addConfig(
             "DontAutoPlayNextVoice",

--- a/TMessagesProj/src/main/res/values-es-rES/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-es-rES/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">Modo fantasma desactivado</string>
     <string name="GhostModeInDrawer">Acceso directo a la pestaña principal</string>
     <string name="GhostModeStatusIndicator">Indicador del Modo Fantasma</string>
+    <string name="GhostModeSoundOverride">Modo Fantasma activo — el sonido está siempre desactivado</string>
     <string name="DontSendReadMessagePackets">No leer mensajes</string>
     <string name="DontReadStoriesPackets">No leer historias</string>
     <string name="DontSendOnlinePackets">No enviar en línea</string>

--- a/TMessagesProj/src/main/res/values-fa-rIR/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-fa-rIR/strings_nax.xml
@@ -114,6 +114,7 @@
     <string name="DisableGhostMode">غیرفعال کردن حالت روح</string>
     <string name="GhostModeEnabled">حالت روح فعال شد</string>
     <string name="GhostModeDisabled">حالت روح غیرفعال شد</string>
+    <string name="GhostModeSoundOverride">حالت روح فعال است — صدا همیشه خاموش است</string>
     <string name="GhostModeInDrawer">نمایش در منوی کشویی</string>
     <string name="DontSendReadMessagePackets">پیام‌ها خوانده نشود</string>
     <string name="DontReadStoriesPackets">استوری‌ها خوانده نشود</string>

--- a/TMessagesProj/src/main/res/values-in-rID/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-in-rID/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">Mode hantu dinonaktifkan</string>
     <string name="GhostModeInDrawer">Pintasan Tab Utama</string>
     <string name="GhostModeStatusIndicator">Indikator Mode Hantu</string>
+    <string name="GhostModeSoundOverride">Mode Hantu aktif — suara selalu mati</string>
     <string name="DontSendReadMessagePackets">Jangan Baca Pesan</string>
     <string name="DontReadStoriesPackets">Jangan Baca Cerita</string>
     <string name="DontSendOnlinePackets">Jangan Kirim Online</string>

--- a/TMessagesProj/src/main/res/values-it-rIT/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-it-rIT/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">Modalità Ghost disattivata</string>
     <string name="GhostModeInDrawer">Scorciatoia scheda principale</string>
     <string name="GhostModeStatusIndicator">Indicatore Modalità Fantasma</string>
+    <string name="GhostModeSoundOverride">Modalità Ghost attiva — il suono è sempre disattivato</string>
     <string name="DontSendReadMessagePackets">Non Leggere Messaggi</string>
     <string name="DontReadStoriesPackets">Non Leggere Storie</string>
     <string name="DontSendOnlinePackets">Non Inviare stato Online</string>

--- a/TMessagesProj/src/main/res/values-ja-rJP/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-ja-rJP/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">ゴーストモードが無効です</string>
     <string name="GhostModeInDrawer">ショートカット</string>
     <string name="GhostModeStatusIndicator">ゴーストモード標識</string>
+    <string name="GhostModeSoundOverride">ゴーストモードが有効です — 音声は常にオフです</string>
     <string name="DontSendReadMessagePackets">メッセージの既読を送信しない</string>
     <string name="DontReadStoriesPackets">ストーリーの既読を送信しない</string>
     <string name="DontSendOnlinePackets">オンライン状態を送信しない</string>

--- a/TMessagesProj/src/main/res/values-pl-rPL/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-pl-rPL/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">Wyłączono tryb ducha</string>
     <string name="GhostModeInDrawer">Skrót do karty głównej</string>
     <string name="GhostModeStatusIndicator">Wskaźnik trybu ducha</string>
+    <string name="GhostModeSoundOverride">Tryb ducha aktywny — dźwięk jest zawsze wyłączony</string>
     <string name="DontSendReadMessagePackets">Nie czytaj wiadomości</string>
     <string name="DontReadStoriesPackets">Nie czytaj storek</string>
     <string name="DontSendOnlinePackets">Nie wysyłaj online</string>

--- a/TMessagesProj/src/main/res/values-pt-rBR/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-pt-rBR/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">Modo fantasma desativado</string>
     <string name="GhostModeInDrawer">Atalho na aba principal</string>
     <string name="GhostModeStatusIndicator">Indicador do modo fantasma</string>
+    <string name="GhostModeSoundOverride">Modo fantasma ativo — o som está sempre desativado</string>
     <string name="DontSendReadMessagePackets">Não ler mensagens</string>
     <string name="DontReadStoriesPackets">Não visualizar stories</string>
     <string name="DontSendOnlinePackets">Ocultar status online</string>

--- a/TMessagesProj/src/main/res/values-ru-rRU/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-ru-rRU/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">Режим «Призрака» выключен</string>
     <string name="GhostModeInDrawer">Ярлык на вкладке «Настройки»</string>
     <string name="GhostModeStatusIndicator">Индикатор режима «Призрака»</string>
+    <string name="GhostModeSoundOverride">Режим «Призрака» активен — звук всегда выключен</string>
     <string name="DontSendReadMessagePackets">Не читать сообщения</string>
     <string name="DontReadStoriesPackets">Не читать истории</string>
     <string name="DontSendOnlinePackets">Не отправлять онлайн-статус</string>

--- a/TMessagesProj/src/main/res/values-tr-rTR/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-tr-rTR/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">Hayalet modu kapatıldı</string>
     <string name="GhostModeInDrawer">Ana Sekme Kısayolu</string>
     <string name="GhostModeStatusIndicator">Hayalet Modu Göstergesi</string>
+    <string name="GhostModeSoundOverride">Hayalet Modu aktif — ses her zaman kapalı</string>
     <string name="DontSendReadMessagePackets">Mesajları Okundu İşaretleme</string>
     <string name="DontReadStoriesPackets">Hikayeleri Okundu İşaretleme</string>
     <string name="DontSendOnlinePackets">Çevrimiçi Bilgisini Gönderme</string>

--- a/TMessagesProj/src/main/res/values-uk-rUA/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-uk-rUA/strings_nax.xml
@@ -134,6 +134,7 @@
     <string name="GhostModeEnabled">Режим \"привид\" увімкнено</string>
     <string name="GhostModeDisabled">Режим \"привид\" вимкнено</string>
     <string name="GhostModeStatusIndicator">Індикатор режиму «привид»</string>
+    <string name="GhostModeSoundOverride">Режим «привид» активний — звук завжди вимкнено</string>
     <string name="DontSendReadMessagePackets">Не читати повідомлення</string>
     <string name="DontReadStoriesPackets">Не читати історії</string>
     <string name="DontSendOnlinePackets">Не надсилати онлайн-статус</string>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">幽灵模式已禁用</string>
     <string name="GhostModeInDrawer">快捷方式</string>
     <string name="GhostModeStatusIndicator">幽灵模式指示器</string>
+    <string name="GhostModeSoundOverride">幽灵模式已启用 — 声音始终关闭</string>
     <string name="DontSendReadMessagePackets">不显示消息已读</string>
     <string name="DontReadStoriesPackets">不显示动态已读</string>
     <string name="DontSendOnlinePackets">不发送在线状态</string>

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_nax.xml
@@ -135,6 +135,7 @@
     <string name="GhostModeDisabled">幽靈模式已停用</string>
     <string name="GhostModeInDrawer">主頁快捷方式</string>
     <string name="GhostModeStatusIndicator">幽靈模式指示器</string>
+    <string name="GhostModeSoundOverride">幽靈模式已啟用 — 聲音始終關閉</string>
     <string name="DontSendReadMessagePackets">不顯示訊息已讀</string>
     <string name="DontReadStoriesPackets">不顯示動態已讀</string>
     <string name="DontSendOnlinePackets">不傳送線上狀態</string>

--- a/TMessagesProj/src/main/res/values/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values/strings_nax.xml
@@ -148,6 +148,7 @@
     <string name="GhostModeDisabled">Ghost mode turned off</string>
     <string name="GhostModeInDrawer">Shortcut</string>
     <string name="GhostModeStatusIndicator">Ghost Mode Indicator</string>
+    <string name="GhostModeSoundOverride">Ghost Mode is active — sound is always off</string>
     <string name="DontSendReadMessagePackets">Don\'t Read Messages</string>
     <string name="DontReadStoriesPackets">Don\'t Read Stories</string>
     <string name="DontSendOnlinePackets">Don\'t Send Online</string>


### PR DESCRIPTION
---                                                                                                                                                                                                                                                                                                                      
  Summary                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                           
  - Added forward options (Author, Caption, Sound) toggle buttons and folder filter tabs with swipe gestures to the Share/Forward popup                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                           
  Changes                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                           
  Folder tabs & filtering                                                                                                                                                                                                                                                                                                  
  - Added FilterTabsView as a grid header, populated from user's dialog filters                                                                                                                                                                                                                                            
  - Swipe left/right on chat list switches folders via selectPrevTab/selectNextTab                                                                                                                                                                                                                                         
  - Fixed grid scroll jump on folder switch with scrollToPosition(0)
  - Fixed dialog height jumping by using max dialog count across all folders for onMeasure

  Forward option toggles
  - 3 toggle buttons next to search: Author (quote), Caption, Sound
  - States persist in NaConfig: ForwardHideSenderName, ForwardHideCaption, ForwardNotify
  - Author and Caption are linked: showing author enables caption, hiding caption hides author

  Long-click popup fix
  - Popup now reads current toggle states instead of hardcoded defaults
  - "Show/Hide sender" initializes from toggle, "Send with/without sound" reflects toggle
  - These are one-time overrides — toggle buttons are NOT modified, no save in NaConfigs
  - Forward send path now uses showSendersName and withSound instead of NaConfig directly

  Respect Ghost Mode "Silent message by default" option
  - When SilentMessageByDefault is active, sound toggle is visually dimmed (alpha 0.4) and clicking it shows a toast "Ghost Mode is active — sound is always off"
  - isForwardNotifyEffective() helper returns false when Ghost Mode is on, overriding the toggle
  - Long-click popup still offers "Send with sound" as a one-time override via Ghost Mode
  - SilentMessageByDefault remains untouched for ChatActivity and other send paths

  Translations
  - Added GhostModeSoundOverride string in 12 locales

  ---

<img width="541" height="522" alt="CleanShot 2026-03-27 at 18 55 38" src="https://github.com/user-attachments/assets/df29506b-47c1-44ac-9503-3773aa47adbe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added folder filtering and navigation in the share dialog for organizing shared content across different filters.
  * Enhanced forwarding options with new toggles to control sender visibility, caption inclusion, and sound/notification settings.
  * Added Ghost Mode sound behavior indicator with support for multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->