### PR TITLE
fix bot draft not replacing on new message

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -25944,7 +25944,7 @@ public class ChatActivity extends BaseFragment implements
         if (!arr.isEmpty()) {
             if ((chatMode == MODE_SCHEDULED || chatMode == MODE_QUICK_REPLIES)) {
                 replaceMessageObjects(arr, 0, true);
-            } else if (UserObject.isBotForum(currentUser)) {
+            } else if (currentUser != null && currentUser.bot) {
                 replaceMessageObjects(arr, 0, false);
             }
         }
@@ -26991,7 +26991,7 @@ public class ChatActivity extends BaseFragment implements
                 pinnedMessageObjects.put(messageObject.getId(), messageObject);
             }
             MessageObject old = messagesDict[loadIndex].get(messageObject.getId());
-            if (messageObject.getId() > 0 && old == null && UserObject.isBotForum(currentUser)) {
+            if (messageObject.getId() > 0 && old == null && currentUser != null && currentUser.bot) {
                 old = BotForumHelper.getInstance(currentAccount).onBotForumDraftCheckNewMessages(currentUser.id, (int) getTopicId(), messageObject.getId(), messageObject.messageText.toString());
                 if (old != null) {
                     if (!messages.contains(old)) {


### PR DESCRIPTION
draft bubbles from sendMessageDraft stick around for non-forum bots because replaceMessageObjects and its call in processNewMessages only run the draft-to-message matching when isBotForum is true, while the draft creation path has no such check. widens the condition to all bots.

checked on my bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes in this release.** This update includes internal optimization of conditional logic handling within the messaging system to improve code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->