### PR TITLE
Ignore reactions and the read status of the blocked users

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -11005,6 +11005,17 @@ public class MessagesController extends BaseController implements NotificationCe
         return "";
     }
 
+    private void filterBlockedMessageReactions(long dialogId, TLRPC.TL_messageReactions reactions) {
+        if (!NekoConfig.ignoreBlocked.Bool() || reactions == null || dialogId >= 0) {
+            return;
+        }
+        TLRPC.Chat chat = getChat(-dialogId);
+        if (!ChatObject.isMegagroup(chat)) {
+            return;
+        }
+        MessageHelper.getInstance(currentAccount).filterBlockedMessageReactions(reactions);
+    }
+
     private void updatePrintingStrings() {
         LongSparseArray<LongSparseArray<CharSequence>> newStrings = new LongSparseArray<>();
         LongSparseArray<LongSparseArray<Integer>> newTypes = new LongSparseArray<>();
@@ -18989,6 +19000,7 @@ public class MessagesController extends BaseController implements NotificationCe
             } else if (baseUpdate instanceof TLRPC.TL_updateMessageReactions) {
                 TLRPC.TL_updateMessageReactions update = (TLRPC.TL_updateMessageReactions) baseUpdate;
                 long dialogId = MessageObject.getPeerId(update.peer);
+                filterBlockedMessageReactions(dialogId, update.reactions);
 
                 getMessagesStorage().updateMessageReactions(dialogId, update.msg_id, update.reactions);
                 if (NaConfig.INSTANCE.getSaveLocalLastSeen().Bool()) {
@@ -19948,6 +19960,7 @@ public class MessagesController extends BaseController implements NotificationCe
                     } else if (baseUpdate instanceof TLRPC.TL_updateMessageReactions) {
                         TLRPC.TL_updateMessageReactions update = (TLRPC.TL_updateMessageReactions) baseUpdate;
                         long dialogId = MessageObject.getPeerId(update.peer);
+                        filterBlockedMessageReactions(dialogId, update.reactions);
                         long pendingPaid = StarsController.getInstance(currentAccount).getPendingPaidReactions(dialogId, update.msg_id);
                         if (pendingPaid != 0) {
                             final StarsController starsController = StarsController.getInstance(currentAccount);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -31982,6 +31982,15 @@ public class ChatActivity extends BaseFragment implements
                                     v.setPredictiveCount(finalCount);
                                     reactedView.setSeenCallback(v::setSeenUsers);
                                 }
+                                final int tabIndex = index;
+                                final ReactionTabHolderView tabHolder = (ReactionTabHolderView) tabsView.getChildAt(position);
+                                v.setOnCountChangedListener((view, filteredCount) -> {
+                                    if (tabIndex < 0) {
+                                        tabHolder.setCounter(filteredCount);
+                                    } else {
+                                        tabHolder.setCounter(currentAccount, counters.get(tabIndex), filteredCount);
+                                    }
+                                });
 
                                 container.addView(v);
                                 cachedViews.put(position, v);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedHeaderView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedHeaderView.java
@@ -144,14 +144,14 @@ public class ReactedHeaderView extends FrameLayout {
                         for (Object obj : v.objects) {
                             if (obj instanceof Long) {
                                 long l = (long) obj;
-                                if (fromId != l) {
+                                if (fromId != l && !shouldFilterBlockedPeer(l)) {
                                     usersToRequest.add(l);
                                     dates.add(0);
                                 }
                             } else if (obj instanceof TLRPC.TL_readParticipantDate) {
                                 long userId = ((TLRPC.TL_readParticipantDate) obj).user_id;
                                 int date = ((TLRPC.TL_readParticipantDate) obj).date;
-                                if (fromId != userId) {
+                                if (fromId != userId && !shouldFilterBlockedPeer(userId)) {
                                     usersToRequest.add(userId);
                                     dates.add(date);
                                 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedHeaderView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedHeaderView.java
@@ -33,6 +33,8 @@ import org.telegram.tgnet.TLRPC;
 import org.telegram.tgnet.Vector;
 import org.telegram.ui.ActionBar.Theme;
 
+import tw.nekomimi.nekogram.helpers.MessageHelper;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -235,7 +237,7 @@ public class ReactedHeaderView extends FrameLayout {
         ConnectionsManager.getInstance(currentAccount).sendRequest(getList, (response, error) -> {
             if (response instanceof TLRPC.TL_messages_messageReactionsList) {
                 TLRPC.TL_messages_messageReactionsList list = (TLRPC.TL_messages_messageReactionsList) response;
-                int c = list.count;
+                int c = Math.max(0, list.count - filterBlockedReactionPeers(list.reactions));
                 int ic = list.users.size();
                 LastSeenHelper.saveLastSeenFromPeerReactions(list.reactions, UserConfig.getInstance(currentAccount).getClientUserId());
                 post(() -> {
@@ -277,6 +279,9 @@ public class ReactedHeaderView extends FrameLayout {
                         iconView.animate().alpha(1f).start();
                     }
                     for (TLRPC.User u : list.users) {
+                        if (shouldFilterBlockedPeer(u.id)) {
+                            continue;
+                        }
                         if (message.messageOwner.from_id != null && u.id != message.messageOwner.from_id.user_id) {
                             boolean hasSame = false;
                             for (int i = 0; i < users.size(); i++) {
@@ -291,6 +296,9 @@ public class ReactedHeaderView extends FrameLayout {
                         }
                     }
                     for (TLRPC.Chat u : list.chats) {
+                        if (shouldFilterBlockedPeer(-u.id)) {
+                            continue;
+                        }
                         if (message.messageOwner.from_id != null && u.id != message.messageOwner.from_id.user_id) {
                             boolean hasSame = false;
                             for (int i = 0; i < users.size(); i++) {
@@ -309,6 +317,30 @@ public class ReactedHeaderView extends FrameLayout {
                 });
             }
         }, ConnectionsManager.RequestFlagInvokeAfter);
+    }
+
+    private int filterBlockedReactionPeers(List<TLRPC.MessagePeerReaction> reactions) {
+        if (reactions == null || reactions.isEmpty()) {
+            return 0;
+        }
+        int removed = 0;
+        for (int i = reactions.size() - 1; i >= 0; i--) {
+            TLRPC.MessagePeerReaction reaction = reactions.get(i);
+            if (reaction == null || reaction.peer_id == null) {
+                continue;
+            }
+            long peerId = MessageObject.getPeerId(reaction.peer_id);
+            if (shouldFilterBlockedPeer(peerId)) {
+                reactions.remove(i);
+                removed++;
+            }
+        }
+        return removed;
+    }
+
+    private boolean shouldFilterBlockedPeer(long peerId) {
+        return peerId != 0 && message != null && message.isSupergroup() &&
+                MessageHelper.getInstance(currentAccount).isBlockedOrFilteredPeer(peerId);
     }
 
     public List<UserSeen> getSeenUsers() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedUsersListView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedUsersListView.java
@@ -66,6 +66,7 @@ public class ReactedUsersListView extends FrameLayout {
     private OnHeightChangedListener onHeightChangedListener;
     private OnProfileSelectedListener onProfileSelectedListener;
     private OnCustomEmojiSelectedListener onCustomEmojiSelectedListener;
+    private OnCountChangedListener onCountChangedListener;
     ArrayList<ReactionsLayoutInBubble.VisibleReaction> customReactionsEmoji = new ArrayList<>();
     ArrayList<TLRPC.InputStickerSet> customEmojiStickerSets = new ArrayList<>();
     MessageContainsEmojiButton messageContainsEmojiButton;
@@ -286,7 +287,10 @@ public class ReactedUsersListView extends FrameLayout {
                     TLRPC.TL_messages_messageReactionsList res = (TLRPC.TL_messages_messageReactionsList) response;
                     MessagesController.getInstance(currentAccount).putUsers(res.users, false);
                     MessagesController.getInstance(currentAccount).putChats(res.chats, false);
-                    filterBlockedReactionPeers(res.reactions);
+                    int filteredCount = Math.max(0, res.count - filterBlockedReactionPeers(res.reactions));
+                    if (onCountChangedListener != null) {
+                        onCountChangedListener.onCountChanged(this, filteredCount);
+                    }
                     LastSeenHelper.saveLastSeenFromPeerReactions(res.reactions, UserConfig.getInstance(currentAccount).getClientUserId());
 
                     HashSet<ReactionsLayoutInBubble.VisibleReaction> visibleCustomEmojiReactions = new HashSet<>();
@@ -427,8 +431,17 @@ public class ReactedUsersListView extends FrameLayout {
         return this;
     }
 
+    public ReactedUsersListView setOnCountChangedListener(OnCountChangedListener onCountChangedListener) {
+        this.onCountChangedListener = onCountChangedListener;
+        return this;
+    }
+
     public interface OnHeightChangedListener {
         void onHeightChanged(ReactedUsersListView view, int newHeight);
+    }
+
+    public interface OnCountChangedListener {
+        void onCountChanged(ReactedUsersListView view, int count);
     }
 
     public interface OnProfileSelectedListener {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedUsersListView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedUsersListView.java
@@ -31,6 +31,8 @@ import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Cells.ReactedUserHolderView;
 import org.telegram.ui.Components.Reactions.ReactionsLayoutInBubble;
 
+import tw.nekomimi.nekogram.helpers.MessageHelper;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -273,6 +275,7 @@ public class ReactedUsersListView extends FrameLayout {
                     TLRPC.TL_messages_messageReactionsList res = (TLRPC.TL_messages_messageReactionsList) response;
                     MessagesController.getInstance(currentAccount).putUsers(res.users, false);
                     MessagesController.getInstance(currentAccount).putChats(res.chats, false);
+                    filterBlockedReactionPeers(res.reactions);
                     LastSeenHelper.saveLastSeenFromPeerReactions(res.reactions, UserConfig.getInstance(currentAccount).getClientUserId());
 
                     HashSet<ReactionsLayoutInBubble.VisibleReaction> visibleCustomEmojiReactions = new HashSet<>();
@@ -338,6 +341,26 @@ public class ReactedUsersListView extends FrameLayout {
                 }
             }));
         }, ConnectionsManager.RequestFlagInvokeAfter);
+    }
+
+    private int filterBlockedReactionPeers(List<TLRPC.MessagePeerReaction> reactions) {
+        if (reactions == null || reactions.isEmpty() || message == null || !message.isSupergroup()) {
+            return 0;
+        }
+        MessageHelper messageHelper = MessageHelper.getInstance(currentAccount);
+        int removed = 0;
+        for (int i = reactions.size() - 1; i >= 0; i--) {
+            TLRPC.MessagePeerReaction reaction = reactions.get(i);
+            if (reaction == null || reaction.peer_id == null) {
+                continue;
+            }
+            long peerId = MessageObject.getPeerId(reaction.peer_id);
+            if (peerId != 0 && messageHelper.isBlockedOrFilteredPeer(peerId)) {
+                reactions.remove(i);
+                removed++;
+            }
+        }
+        return removed;
     }
 
     private void updateCustomReactionsButton() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedUsersListView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactedUsersListView.java
@@ -200,6 +200,9 @@ public class ReactedUsersListView extends FrameLayout {
     public ReactedUsersListView setSeenUsers(List<ReactedHeaderView.UserSeen> users) {
         if (userReactions != null && !userReactions.isEmpty()) {
             for (ReactedHeaderView.UserSeen p : users) {
+                if (shouldFilterBlockedPeer(p.dialogId)) {
+                    continue;
+                }
                 TLObject user = p.user;
                 if (user != null && p.date > 0) {
                     for (int i = 0; i < userReactions.size(); ++i) {
@@ -215,6 +218,9 @@ public class ReactedUsersListView extends FrameLayout {
         }
         List<TLRPC.TL_messagePeerReaction> nr = new ArrayList<>(users.size());
         for (ReactedHeaderView.UserSeen p : users) {
+            if (shouldFilterBlockedPeer(p.dialogId)) {
+                continue;
+            }
             ArrayList<TLRPC.MessagePeerReaction> userReactions = peerReactionMap.get(p.dialogId);
             if (userReactions != null) {
                continue;
@@ -244,6 +250,11 @@ public class ReactedUsersListView extends FrameLayout {
         adapter.notifyDataSetChanged();
         updateHeight();
         return this;
+    }
+
+    private boolean shouldFilterBlockedPeer(long peerId) {
+        return peerId != 0 && message != null && message.isSupergroup() &&
+                MessageHelper.getInstance(currentAccount).isBlockedOrFilteredPeer(peerId);
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactionTabHolderView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ReactionTabHolderView.java
@@ -105,8 +105,12 @@ public class ReactionTabHolderView extends FrameLayout {
     }
 
     public void setCounter(int currentAccount, TLRPC.ReactionCount counter) {
-        this.count = counter.count;
-        counterView.setText(String.format("%s", LocaleController.formatShortNumber(counter.count, null)));
+        setCounter(currentAccount, counter, counter.count);
+    }
+
+    public void setCounter(int currentAccount, TLRPC.ReactionCount counter, int count) {
+        this.count = count;
+        counterView.setText(String.format("%s", LocaleController.formatShortNumber(count, null)));
         ReactionsLayoutInBubble.VisibleReaction counterReaction = ReactionsLayoutInBubble.VisibleReaction.fromTL(counter.reaction);
         reaction = counterReaction;
         if (reaction.emojicon != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/MessageSeenView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MessageSeenView.java
@@ -48,6 +48,8 @@ import org.telegram.ui.Components.MessageSeenCheckDrawable;
 import org.telegram.ui.Components.RecyclerListView;
 import org.telegram.ui.Components.StatusBadgeComponent;
 
+import tw.nekomimi.nekogram.helpers.MessageHelper;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -117,7 +119,7 @@ public class MessageSeenView extends FrameLayout {
                     if (object instanceof TLRPC.TL_readParticipantDate) {
                         int date = ((TLRPC.TL_readParticipantDate) object).date;
                         Long peerId = ((TLRPC.TL_readParticipantDate) object).user_id;
-                        if (finalFromId == peerId) {
+                        if (finalFromId == peerId || shouldFilterBlockedPeer(chat, peerId)) {
                             continue;
                         }
                         TLRPC.User user = MessagesController.getInstance(currentAccount).getUser(peerId);
@@ -129,7 +131,7 @@ public class MessageSeenView extends FrameLayout {
                         }
                     } else if (object instanceof Long) {
                         Long peerId = (Long) object;
-                        if (finalFromId == peerId) {
+                        if (finalFromId == peerId || shouldFilterBlockedPeer(chat, peerId)) {
                             continue;
                         }
                         if (peerId > 0) {
@@ -212,6 +214,11 @@ public class MessageSeenView extends FrameLayout {
         }));
         setBackground(Theme.createRadSelectorDrawable(Theme.getColor(Theme.key_dialogButtonSelector), 6, 0));
         setEnabled(false);
+    }
+
+    private boolean shouldFilterBlockedPeer(TLRPC.Chat chat, long peerId) {
+        return peerId != 0 && ChatObject.isMegagroup(chat) &&
+                MessageHelper.getInstance(currentAccount).isBlockedOrFilteredPeer(peerId);
     }
 
     boolean ignoreLayout;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/MessageHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/MessageHelper.java
@@ -1042,13 +1042,76 @@ public class MessageHelper extends BaseController {
         return getMessagesController().blockePeers.indexOfKey(senderId) >= 0 || AyuFilter.isCustomFilteredPeer(senderId);
     }
 
+    public boolean isBlockedOrFilteredPeer(long peerId) {
+        return isBlockedUser(peerId) || AyuFilter.isBlockedChannel(peerId);
+    }
+
     public boolean isBlockedOrFiltered(TLRPC.Message message) {
         if (message == null) {
             return false;
         }
         long fromId = MessageObject.getFromChatId(message);
-        boolean blocked =  isBlockedUser(fromId) || AyuFilter.isBlockedChannel(fromId);
+        boolean blocked = isBlockedOrFilteredPeer(fromId);
         return blocked || AyuFilter.isFiltered(new MessageObject(currentAccount, message, false, false), null);
+    }
+
+    public boolean filterBlockedMessageReactions(TLRPC.TL_messageReactions reactions) {
+        if (reactions == null || !NekoConfig.ignoreBlocked.Bool()) {
+            return false;
+        }
+        boolean changed = false;
+        if (reactions.recent_reactions != null) {
+            for (int i = reactions.recent_reactions.size() - 1; i >= 0; i--) {
+                TLRPC.MessagePeerReaction reaction = reactions.recent_reactions.get(i);
+                if (reaction == null || reaction.peer_id == null) {
+                    continue;
+                }
+                long peerId = MessageObject.getPeerId(reaction.peer_id);
+                if (peerId != 0 && isBlockedOrFilteredPeer(peerId)) {
+                    reactions.recent_reactions.remove(i);
+                    decrementReactionCount(reactions, reaction.reaction);
+                    changed = true;
+                }
+            }
+        }
+        if (reactions.top_reactors != null) {
+            for (int i = reactions.top_reactors.size() - 1; i >= 0; i--) {
+                TLRPC.MessageReactor reactor = reactions.top_reactors.get(i);
+                if (reactor == null || reactor.peer_id == null) {
+                    continue;
+                }
+                long peerId = MessageObject.getPeerId(reactor.peer_id);
+                if (peerId != 0 && isBlockedOrFilteredPeer(peerId)) {
+                    reactions.top_reactors.remove(i);
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
+    private static void decrementReactionCount(TLRPC.TL_messageReactions reactions, TLRPC.Reaction removedReaction) {
+        if (removedReaction == null || reactions.results == null) {
+            return;
+        }
+        for (int i = reactions.results.size() - 1; i >= 0; i--) {
+            TLRPC.ReactionCount count = reactions.results.get(i);
+            if (count == null || !sameReaction(count.reaction, removedReaction)) {
+                continue;
+            }
+            count.count--;
+            if (count.count <= 0) {
+                reactions.results.remove(i);
+            }
+            return;
+        }
+    }
+
+    private static boolean sameReaction(TLRPC.Reaction first, TLRPC.Reaction second) {
+        if (first == null || second == null) {
+            return false;
+        }
+        return first.equals(second) || first instanceof TLRPC.TL_reactionPaid && second instanceof TLRPC.TL_reactionPaid;
     }
 
     public static void copyVideoFrameToClipboard(File videoFile, long positionMs, View bulletinContainer, Theme.ResourcesProvider resourcesProvider, Runnable fallbackAction) {


### PR DESCRIPTION
忽略掉被屏蔽用户的已读状态和点击reaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked and filtered accounts are now properly excluded from message reaction displays and read/seen participant lists.

* **New Features**
  * Reaction lists and counters now omit filtered peers, so tab counters and reaction headers reflect visible users only.
  * Reaction user lists report adjusted counts when blocked/filtered peers are removed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/risin42/NagramX/pull/359)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->