### PR TITLE
add .nomedia file

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -2514,7 +2514,7 @@ public class ImageLoader {
                         File imagePath = new File(telegramPath, "Telegram Images");
                         imagePath.mkdir();
                         if (imagePath.isDirectory() && canMoveFiles(cachePath, imagePath, FileLoader.MEDIA_DIR_IMAGE)) {
-                            AndroidUtilities.createEmptyFile(new File(audioPath, ".nomedia"));
+                            AndroidUtilities.createEmptyFile(new File(imagePath, ".nomedia"));
                             mediaDirs.put(FileLoader.MEDIA_DIR_IMAGE, imagePath);
                             if (BuildVars.LOGS_ENABLED) {
                                 FileLog.d("image path = " + imagePath);
@@ -2528,7 +2528,7 @@ public class ImageLoader {
                         File videoPath = new File(telegramPath, "Telegram Video");
                         videoPath.mkdir();
                         if (videoPath.isDirectory() && canMoveFiles(cachePath, videoPath, FileLoader.MEDIA_DIR_VIDEO)) {
-                            AndroidUtilities.createEmptyFile(new File(audioPath, ".nomedia"));
+                            AndroidUtilities.createEmptyFile(new File(videoPath, ".nomedia"));
                             mediaDirs.put(FileLoader.MEDIA_DIR_VIDEO, videoPath);
                             if (BuildVars.LOGS_ENABLED) {
                                 FileLog.d("video path = " + videoPath);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -2514,6 +2514,7 @@ public class ImageLoader {
                         File imagePath = new File(telegramPath, "Telegram Images");
                         imagePath.mkdir();
                         if (imagePath.isDirectory() && canMoveFiles(cachePath, imagePath, FileLoader.MEDIA_DIR_IMAGE)) {
+                            AndroidUtilities.createEmptyFile(new File(audioPath, ".nomedia"));
                             mediaDirs.put(FileLoader.MEDIA_DIR_IMAGE, imagePath);
                             if (BuildVars.LOGS_ENABLED) {
                                 FileLog.d("image path = " + imagePath);
@@ -2527,6 +2528,7 @@ public class ImageLoader {
                         File videoPath = new File(telegramPath, "Telegram Video");
                         videoPath.mkdir();
                         if (videoPath.isDirectory() && canMoveFiles(cachePath, videoPath, FileLoader.MEDIA_DIR_VIDEO)) {
+                            AndroidUtilities.createEmptyFile(new File(audioPath, ".nomedia"));
                             mediaDirs.put(FileLoader.MEDIA_DIR_VIDEO, videoPath);
                             if (BuildVars.LOGS_ENABLED) {
                                 FileLog.d("video path = " + videoPath);


### PR DESCRIPTION
Add .nomedia files to the Telegram Images and Telegram Video folders to prevent cached images and videos from being scanned by the system gallery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures newly moved or initialized photo and video folders receive hidden placeholders so they are excluded from system media scanning, preventing migrated media from appearing in galleries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/risin42/NagramX/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->