### PR TITLE
Feature/quick scheduled send

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -3690,14 +3690,27 @@ public class ChatActivityEnterView extends FrameLayout implements
         messageEditTextContainer.addView(scheduledButton, 2, LayoutHelper.createFrame(DEFAULT_HEIGHT, DEFAULT_HEIGHT, Gravity.BOTTOM | Gravity.RIGHT));
         scheduledButton.setOnClickListener(v -> {
             if (delegate == null) return;
-            boolean hasText = messageEditText != null && !TextUtils.isEmpty(messageEditText.getText());
-            if (NaConfig.INSTANCE.getQuickScheduleButton().Bool() && hasText && delegate.hasScheduledMessages()) {
-                AlertsCreator.createScheduleDatePickerDialog(parentActivity, dialog_id, (notify, scheduleDate, scheduleRepeatPeriod) -> {
+            CharSequence text = messageEditText != null ? messageEditText.getText() : null;
+            boolean hasText = text != null && AndroidUtilities.getTrimmedString(text).length() > 0;
+            if (NaConfig.INSTANCE.getQuickScheduleButton().Bool()
+                    && hasText
+                    && editingMessageObject == null
+                    && parentActivity != null
+                    && delegate.hasScheduledMessages()) {
+                long quickScheduleDialogId = parentFragment != null ? parentFragment.getDialogId() : dialog_id;
+                AlertsCreator.createScheduleDatePickerDialog(parentActivity, quickScheduleDialogId, (notify, scheduleDate, scheduleRepeatPeriod) -> {
                     sendMessageInternal(notify, scheduleDate, scheduleRepeatPeriod, 0, true);
                 }, resourcesProvider);
             } else {
                 delegate.openScheduledMessages();
             }
+        });
+        scheduledButton.setOnLongClickListener(v -> {
+            if (delegate != null) {
+                delegate.openScheduledMessages();
+                return true;
+            }
+            return false;
         });
         scheduledButton.setTranslationX(0);
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -3689,7 +3689,13 @@ public class ChatActivityEnterView extends FrameLayout implements
         scheduledButton.setBackground(Theme.createSelectorDrawable(getThemedColor(Theme.key_listSelector)));
         messageEditTextContainer.addView(scheduledButton, 2, LayoutHelper.createFrame(DEFAULT_HEIGHT, DEFAULT_HEIGHT, Gravity.BOTTOM | Gravity.RIGHT));
         scheduledButton.setOnClickListener(v -> {
-            if (delegate != null) {
+            if (delegate == null) return;
+            boolean hasText = messageEditText != null && !TextUtils.isEmpty(messageEditText.getText());
+            if (NaConfig.INSTANCE.getQuickScheduleButton().Bool() && hasText && delegate.hasScheduledMessages()) {
+                AlertsCreator.createScheduleDatePickerDialog(parentActivity, dialog_id, (notify, scheduleDate, scheduleRepeatPeriod) -> {
+                    sendMessageInternal(notify, scheduleDate, scheduleRepeatPeriod, 0, true);
+                }, resourcesProvider);
+            } else {
                 delegate.openScheduledMessages();
             }
         });
@@ -8902,14 +8908,27 @@ public class ChatActivityEnterView extends FrameLayout implements
                                 animators.add(ObjectAnimator.ofFloat(attachButton, View.SCALE_Y, 0.5f));
                             }
                             boolean hasScheduled = delegate != null && delegate.hasScheduledMessages();
-                            scheduleButtonHidden = true;
+                            boolean keepScheduleVisible = NaConfig.INSTANCE.getQuickScheduleButton().Bool() && hasScheduled;
+                            if (keepScheduleVisible) {
+                                createScheduledButton();
+                            }
+                            scheduleButtonHidden = !keepScheduleVisible;
                             if (scheduledButton != null) {
                                 scheduledButton.setScaleY(1.0f);
                                 if (hasScheduled) {
-                                    scheduledButton.setTag(null);
-                                    animators.add(ObjectAnimator.ofFloat(scheduledButton, View.ALPHA, 0.0f));
-                                    animators.add(ObjectAnimator.ofFloat(scheduledButton, View.SCALE_X, 0.0f));
-                                    animators.add(animateScheduledTranslationX(0));
+                                    if (keepScheduleVisible) {
+                                        scheduledButton.setVisibility(VISIBLE);
+                                        scheduledButton.setTag(1);
+                                        scheduledButton.setPivotX(dp(DEFAULT_HEIGHT));
+                                        animators.add(ObjectAnimator.ofFloat(scheduledButton, View.ALPHA, 1.0f));
+                                        animators.add(ObjectAnimator.ofFloat(scheduledButton, View.SCALE_X, 1.0f));
+                                        animators.add(animateScheduledTranslationX(dp(DEFAULT_HEIGHT)));
+                                    } else {
+                                        scheduledButton.setTag(null);
+                                        animators.add(ObjectAnimator.ofFloat(scheduledButton, View.ALPHA, 0.0f));
+                                        animators.add(ObjectAnimator.ofFloat(scheduledButton, View.SCALE_X, 0.0f));
+                                        animators.add(animateScheduledTranslationX(0));
+                                    }
                                 } else {
                                     scheduledButton.setAlpha(0.0f);
                                     scheduledButton.setScaleX(0.0f);
@@ -8923,7 +8942,7 @@ public class ChatActivityEnterView extends FrameLayout implements
                                 public void onAnimationEnd(Animator animation) {
                                     if (animation.equals(runningAnimation2)) {
                                         attachLayout.setVisibility(GONE);
-                                        if (hasScheduled && scheduledButton != null) {
+                                        if (hasScheduled && scheduledButton != null && !keepScheduleVisible) {
                                             scheduledButton.setVisibility(GONE);
                                         }
                                         runningAnimation2 = null;
@@ -9086,16 +9105,30 @@ public class ChatActivityEnterView extends FrameLayout implements
                             updateFieldRight(1);
                         }
                     }
-                    scheduleButtonHidden = true;
+                    boolean hasScheduledInstant = delegate != null && delegate.hasScheduledMessages();
+                    boolean keepScheduleVisibleInstant = NaConfig.INSTANCE.getQuickScheduleButton().Bool() && hasScheduledInstant;
+                    if (keepScheduleVisibleInstant) {
+                        createScheduledButton();
+                    }
+                    scheduleButtonHidden = !keepScheduleVisibleInstant;
                     if (scheduledButton != null) {
-                        if (delegate != null && delegate.hasScheduledMessages()) {
-                            scheduledButton.setVisibility(GONE);
-                            scheduledButton.setTag(null);
+                        if (keepScheduleVisibleInstant) {
+                            scheduledButton.setVisibility(VISIBLE);
+                            scheduledButton.setTag(1);
+                            scheduledButton.setAlpha(1.0f);
+                            scheduledButton.setScaleX(1.0f);
+                            scheduledButton.setScaleY(1.0f);
+                            scheduledButton.setTranslationX(dp(DEFAULT_HEIGHT));
+                        } else {
+                            if (hasScheduledInstant) {
+                                scheduledButton.setVisibility(GONE);
+                                scheduledButton.setTag(null);
+                            }
+                            scheduledButton.setAlpha(0.0f);
+                            scheduledButton.setScaleX(0.0f);
+                            scheduledButton.setScaleY(1.0f);
+                            scheduledButton.setTranslationX(0);
                         }
-                        scheduledButton.setAlpha(0.0f);
-                        scheduledButton.setScaleX(0.0f);
-                        scheduledButton.setScaleY(1.0f);
-                        scheduledButton.setTranslationX(0);
                     }
                 }
             } else {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoChatSettingsActivity.java
@@ -115,6 +115,7 @@ public class NekoChatSettingsActivity extends BaseNekoXSettingsActivity implemen
     private final AbstractConfigCell unreadBadgeOnBackButton = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.unreadBadgeOnBackButton));
     private final AbstractConfigCell sendCommentAfterForwardRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.sendCommentAfterForward));
     private final AbstractConfigCell useChatAttachMediaMenuRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.useChatAttachMediaMenu, getString(R.string.UseChatAttachEnterMenuNotice)));
+    private final AbstractConfigCell quickScheduleButtonRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getQuickScheduleButton(), getString(R.string.QuickScheduleButtonNotice)));
     private final AbstractConfigCell fixLinkPreviewRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getFixLinkPreview(), "x.com -> fixupx.com"));
     private final AbstractConfigCell disableLinkPreviewByDefaultRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.disableLinkPreviewByDefault));
     private final AbstractConfigCell deleteChatForBothSidesRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getDeleteChatForBothSides()));

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1247,6 +1247,12 @@ object NaConfig {
             ConfigItem.configTypeInt,
             NekoConfig.MARKDOWN_PARSER_NEKO
         )
+    val quickScheduleButton =
+        addConfig(
+            "QuickScheduleButton",
+            ConfigItem.configTypeBool,
+            false
+        )
     val defaultScheduledTime =
         addConfig(
             "DefaultScheduledTime",

--- a/TMessagesProj/src/main/res/values/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values/strings_nax.xml
@@ -349,4 +349,6 @@
     <string name="DeepLTranslateKey">DeepL API Key</string>
     <string name="DeepLTranslateKeyNotice">Configure DeepL API Key, leave blank to use built-in credentials.</string>
     <string name="DefaultScheduleDelay">Default delay</string>
+    <string name="QuickScheduleButton">Quick Schedule Button</string>
+    <string name="QuickScheduleButtonNotice">Keep calendar button visible when typing to quickly schedule more messages</string>
 </resources>


### PR DESCRIPTION
# Quick Schedule Button

## What

Follow-up to #366 (configurable default scheduled time). Once you have scheduled messages in a chat and start typing, the calendar icon stays visible. Tap it to schedule the message you are typing right now, no long-tap on the send button required.

## Why

I usually use scheduled messages as a "review queue": reply to many people during the day, then review the whole bulk before it goes out. Might be useful for other people using scheduled messages when talking with their friends/relatives abroad with a different time zone as well. Default Telegram flow for this is painful:

- Calendar icon only opens the list of already scheduled messages, not the picker for a new one.
- Long-tap on the send button is the only way to schedule a new message, and that button sits right on the edge of the screen. On devices with curved edges it often does not register, and even when it does it feels slow.
- A permanent "schedule" button in the input bar would clutter UI for everyone who never uses it.

This change solves all three: the button only appears when you already have at least one scheduled message in the chat, no fighting with the curved edge, and one tap instead of long-tap plus menu. The whole thing is behind a toggle that is off by default, so most folks will not notice any difference until they turn it on.

Next step would be improving the scheduled list itself, e.g. bulk send like in Telegram Desktop, but I wanted to start with smaller focused changes first. Easy select first+last+select between flow already implemented so it is already half-way there.

## How

- New opt-in setting `QuickScheduleButton` in Chat settings, off by default.
- In `ChatActivityEnterView`, when the setting is on and the chat has scheduled messages, the calendar button stays visible while typing instead of being hidden.
- Tap behavior is context-aware:
  - empty draft / editing a message / no scheduled messages yet: original behavior (opens the list);
  - non-empty draft with existing scheduled messages: opens the schedule-date picker and sends the typed text at chosen time.
- Long-tap always opens the scheduled messages list, preserving the original affordance.

## Notes

- Edit-message flow is excluded from the quick-schedule path to avoid sending instead of editing.
- Whitespace-only drafts are treated as empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Quick Schedule button feature in chat settings. When enabled, tapping the scheduled button opens the date picker for immediate message scheduling, streamlining the workflow. Button visibility and animations update dynamically based on feature state and message content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/risin42/NagramX/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->