### PR TITLE
Improve message filtering

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -8413,6 +8413,32 @@ public class MessageObject {
                     int start = sp.getSpanStart(span);
                     int end = sp.getSpanEnd(span);
                     if (start >= 0 && end > start && end <= sb.length()) {
+                        for (Emoji.EmojiSpan e : sb.getSpans(start, end, Emoji.EmojiSpan.class)) {
+                            final Emoji.EmojiSpan captured = e;
+                            sb.setSpan(new ReplacementSpan() {
+                                @Override
+                                public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
+                                    return captured.getSize(paint, text, s, e2, fm);
+                                }
+                                @Override
+                                public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
+                                }
+                            }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                            sb.removeSpan(e);
+                        }
+                        for (AnimatedEmojiSpan e : sb.getSpans(start, end, AnimatedEmojiSpan.class)) {
+                            final AnimatedEmojiSpan captured = e;
+                            sb.setSpan(new ReplacementSpan() {
+                                @Override
+                                public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
+                                    return captured.getSize(paint, text, s, e2, fm);
+                                }
+                                @Override
+                                public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
+                                }
+                            }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                            sb.removeSpan(e);
+                        }
                         sb.setSpan(new ForegroundColorSpan(Color.TRANSPARENT), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                     }
                 }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -647,8 +647,9 @@ public class MessageObject {
     }
 
     public boolean hasMediaSpoilers() {
+        if (!isRepostPreview && ayuMediaSpoiler && !ayuSpoilerRevealed) return true;
         if (NekoConfig.showSpoilersDirectly.Bool()) return false;
-        return !isRepostPreview && (messageOwner.media != null && (messageOwner.media.spoiler || ayuMediaSpoiler) || needDrawBluredPreview()) || isHiddenSensitive();
+        return !isRepostPreview && (messageOwner.media != null && messageOwner.media.spoiler || needDrawBluredPreview()) || isHiddenSensitive();
     }
 
     public Boolean isSensitiveCached;
@@ -8387,6 +8388,19 @@ public class MessageObject {
                     }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                     sb.removeSpan(e);
                 }
+                for (AnimatedEmojiSpan e : sb.getSpans(start, end, AnimatedEmojiSpan.class)) {
+                    final AnimatedEmojiSpan captured = e;
+                    sb.setSpan(new ReplacementSpan() {
+                        @Override
+                        public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
+                            return captured.getSize(paint, text, s, e2, fm);
+                        }
+                        @Override
+                        public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
+                        }
+                    }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    sb.removeSpan(e);
+                }
                 sb.setSpan(new ForegroundColorSpan(Color.TRANSPARENT), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             }
         }
@@ -8841,7 +8855,8 @@ public class MessageObject {
 
             block.ayuSpoilerGroups = null;
             block.spoilersPatchedTextLayout.set(null);
-            if (!isSpoilersRevealed && !spoiledLoginCode) {
+            boolean hasUnrevealedAyu = ayuSpoilerText != null && !ayuSpoilerRevealed;
+            if ((!isSpoilersRevealed && !spoiledLoginCode) || hasUnrevealedAyu) {
                 int right = linesMaxWidthWithLeft;
                 if (block.quote) {
                     right -= AndroidUtilities.dp(32);
@@ -8849,12 +8864,16 @@ public class MessageObject {
                     right -= AndroidUtilities.dp(15);
                 }
 
-                Spanned ayuBlock = ayuSpoilerBlockSpannable(ayuSpoilerText, block);
-                if (ayuBlock != null) {
-                    ayuBuildSpoilerGroups(block, ayuBlock, right);
-                    ayuPreBuildPatchedLayout(block, ayuBlock);
+                if (hasUnrevealedAyu) {
+                    Spanned ayuBlock = ayuSpoilerBlockSpannable(ayuSpoilerText, block);
+                    if (ayuBlock != null) {
+                        ayuBuildSpoilerGroups(block, ayuBlock, right);
+                        ayuPreBuildPatchedLayout(block, ayuBlock);
+                    }
                 }
-                SpoilerEffect.addSpoilers(null, block.textLayout, -1, right, null, block.spoilers);
+                if (!isSpoilersRevealed && !spoiledLoginCode) {
+                    SpoilerEffect.addSpoilers(null, block.textLayout, -1, right, null, block.spoilers);
+                }
             }
         }
 
@@ -9298,7 +9317,8 @@ public class MessageObject {
 
                 block.ayuSpoilerGroups = null;
                 block.spoilersPatchedTextLayout.set(null);
-                if (messageObject != null && !messageObject.isSpoilersRevealed && !messageObject.spoiledLoginCode) {
+                boolean hasUnrevealedAyu = messageObject != null && messageObject.ayuSpoilerText != null && !messageObject.ayuSpoilerRevealed;
+                if ((messageObject != null && !messageObject.isSpoilersRevealed && !messageObject.spoiledLoginCode) || hasUnrevealedAyu) {
                     int right = linesMaxWidthWithLeft;
                     if (block.quote) {
                         right -= AndroidUtilities.dp(32);
@@ -9306,12 +9326,16 @@ public class MessageObject {
                         right -= AndroidUtilities.dp(15);
                     }
 
-                    Spanned ayuBlock = MessageObject.ayuSpoilerBlockSpannable(messageObject.ayuSpoilerText, block);
-                    if (ayuBlock != null) {
-                        MessageObject.ayuBuildSpoilerGroups(block, ayuBlock, right);
-                        MessageObject.ayuPreBuildPatchedLayout(block, ayuBlock);
+                    if (hasUnrevealedAyu) {
+                        Spanned ayuBlock = MessageObject.ayuSpoilerBlockSpannable(messageObject.ayuSpoilerText, block);
+                        if (ayuBlock != null) {
+                            MessageObject.ayuBuildSpoilerGroups(block, ayuBlock, right);
+                            MessageObject.ayuPreBuildPatchedLayout(block, ayuBlock);
+                        }
                     }
-                    SpoilerEffect.addSpoilers(null, block.textLayout, -1, right, null, block.spoilers);
+                    if (messageObject != null && !messageObject.isSpoilersRevealed && !messageObject.spoiledLoginCode) {
+                        SpoilerEffect.addSpoilers(null, block.textLayout, -1, right, null, block.spoilers);
+                    }
                 }
             }
         }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -8413,32 +8413,7 @@ public class MessageObject {
                     int start = sp.getSpanStart(span);
                     int end = sp.getSpanEnd(span);
                     if (start >= 0 && end > start && end <= sb.length()) {
-                        for (Emoji.EmojiSpan e : sb.getSpans(start, end, Emoji.EmojiSpan.class)) {
-                            final Emoji.EmojiSpan captured = e;
-                            sb.setSpan(new ReplacementSpan() {
-                                @Override
-                                public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
-                                    return captured.getSize(paint, text, s, e2, fm);
-                                }
-                                @Override
-                                public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
-                                }
-                            }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-                            sb.removeSpan(e);
-                        }
-                        for (AnimatedEmojiSpan e : sb.getSpans(start, end, AnimatedEmojiSpan.class)) {
-                            final AnimatedEmojiSpan captured = e;
-                            sb.setSpan(new ReplacementSpan() {
-                                @Override
-                                public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
-                                    return captured.getSize(paint, text, s, e2, fm);
-                                }
-                                @Override
-                                public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
-                                }
-                            }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-                            sb.removeSpan(e);
-                        }
+                        suppressSelfDrawingSpans(sb, start, end);
                         sb.setSpan(new ForegroundColorSpan(Color.TRANSPARENT), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                     }
                 }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -8350,7 +8350,7 @@ public class MessageObject {
             int start = ayuBlock.getSpanStart(span);
             int end = ayuBlock.getSpanEnd(span);
             if (start < 0 || end <= start || end > block.textLayout.getText().length()) continue;
-            SpannableString ss = new SpannableString(block.textLayout.getText());
+            SpannableString ss = new SpannableString(block.textLayout.getText().toString());
             ss.setSpan(span, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             List<SpoilerEffect> group = byColor.computeIfAbsent(span.color, k -> new ArrayList<>());
             SpoilerEffect.addSpoilers(null, block.textLayout, -1, right, ss, null, group, null);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -19,6 +19,7 @@ import static org.telegram.messenger.LocaleController.formatString;
 import static org.telegram.messenger.LocaleController.getString;
 
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
@@ -39,6 +40,8 @@ import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.style.CharacterStyle;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.ReplacementSpan;
 import android.text.style.ClickableSpan;
 import android.text.style.RelativeSizeSpan;
 import android.text.style.URLSpan;
@@ -46,6 +49,7 @@ import android.text.util.Linkify;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.collection.LongSparseArray;
 import androidx.core.graphics.ColorUtils;
 
@@ -264,6 +268,9 @@ public class MessageObject {
     public boolean isMediaSpoilersRevealed;
     public boolean isMediaSpoilersRevealedInSharedMedia;
     public boolean revealingMediaSpoilers;
+    public transient boolean ayuMediaSpoiler;
+    public transient CharSequence ayuSpoilerText;
+    public transient boolean ayuSpoilerRevealed;
     public byte[] sponsoredId;
     public String sponsoredTitle, sponsoredUrl;
     public boolean sponsoredRecommended;
@@ -641,7 +648,7 @@ public class MessageObject {
 
     public boolean hasMediaSpoilers() {
         if (NekoConfig.showSpoilersDirectly.Bool()) return false;
-        return !isRepostPreview && (messageOwner.media != null && messageOwner.media.spoiler || needDrawBluredPreview()) || isHiddenSensitive();
+        return !isRepostPreview && (messageOwner.media != null && (messageOwner.media.spoiler || ayuMediaSpoiler) || needDrawBluredPreview()) || isHiddenSensitive();
     }
 
     public Boolean isSensitiveCached;
@@ -975,6 +982,7 @@ public class MessageObject {
         public int start;
 
         public AtomicReference<Layout> spoilersPatchedTextLayout = new AtomicReference<>();
+        public AtomicReference<Layout> ayuSpoilersPatchedTextLayout = new AtomicReference<>();
         public StaticLayout textLayout;
         public int padTop, padBottom;
         public int charactersOffset;
@@ -984,6 +992,8 @@ public class MessageObject {
         public int heightByOffset;
         public byte directionFlags;
         public List<SpoilerEffect> spoilers = new ArrayList<>();
+        // group of spoilers with their color
+        public List<android.util.Pair<Integer, List<SpoilerEffect>>> ayuSpoilerGroups;
         public float maxRight;
 
         public MessageObject messageObject;
@@ -8300,6 +8310,115 @@ public class MessageObject {
         }
     }
 
+    public static class AyuSpoilerSpan extends TextStyleSpan {
+        public final int color;
+        public AyuSpoilerSpan(int color) {
+            super(makeRun());
+            this.color = color;
+        }
+        private static TextStyleSpan.TextStyleRun makeRun() {
+            TextStyleSpan.TextStyleRun r = new TextStyleSpan.TextStyleRun();
+            r.flags = TextStyleSpan.FLAG_STYLE_SPOILER;
+            return r;
+        }
+    }
+
+    public static Spanned ayuSpoilerBlockSpannable(CharSequence ayuSpoilerText, TextLayoutBlock block) {
+        if (!(ayuSpoilerText instanceof Spanned)) return null;
+        Spanned full = (Spanned) ayuSpoilerText;
+        int bStart = block.charactersOffset;
+        int bEnd = block.charactersEnd;
+        AyuSpoilerSpan[] ayuSpans = full.getSpans(bStart, bEnd, AyuSpoilerSpan.class);
+        SpannableStringBuilder bs = null;
+        for (AyuSpoilerSpan span : ayuSpans) {
+            if (bs == null) bs = new SpannableStringBuilder(block.textLayout.getText());
+            int ss = full.getSpanStart(span);
+            int se = full.getSpanEnd(span);
+            int as = Math.max(0, ss - bStart);
+            int ae = Math.min(bEnd - bStart, se - bStart);
+            if (as < ae) {
+                bs.setSpan(new AyuSpoilerSpan(span.color), as, ae, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+        }
+        return bs;
+    }
+
+    public static void ayuBuildSpoilerGroups(TextLayoutBlock block, Spanned ayuBlock, int right) {
+        AyuSpoilerSpan[] spans = ayuBlock.getSpans(0, ayuBlock.length(), AyuSpoilerSpan.class);
+        java.util.LinkedHashMap<Integer, List<SpoilerEffect>> byColor = new java.util.LinkedHashMap<>();
+        for (AyuSpoilerSpan span : spans) {
+            int start = ayuBlock.getSpanStart(span);
+            int end = ayuBlock.getSpanEnd(span);
+            if (start < 0 || end <= start || end > block.textLayout.getText().length()) continue;
+            SpannableString ss = new SpannableString(block.textLayout.getText());
+            ss.setSpan(span, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            List<SpoilerEffect> group = byColor.computeIfAbsent(span.color, k -> new ArrayList<>());
+            SpoilerEffect.addSpoilers(null, block.textLayout, -1, right, ss, null, group, null);
+        }
+        block.ayuSpoilerGroups = new ArrayList<>();
+        for (java.util.Map.Entry<Integer, List<SpoilerEffect>> e : byColor.entrySet()) {
+            if (!e.getValue().isEmpty()) {
+                block.ayuSpoilerGroups.add(new android.util.Pair<>(e.getKey(), e.getValue()));
+            }
+        }
+    }
+
+    public static void ayuPreBuildPatchedLayout(TextLayoutBlock block, Spanned ayuBlock) {
+        if (block.ayuSpoilerGroups == null || block.ayuSpoilerGroups.isEmpty()) return;
+        SpannableStringBuilder sb = new SpannableStringBuilder(block.textLayout.getText());
+
+        // make all emoji span into proper span that can be hide properly
+        // then make filter spoiler mask transparent
+        AyuSpoilerSpan[] ayuSpans = ayuBlock.getSpans(0, ayuBlock.length(), AyuSpoilerSpan.class);
+        for (AyuSpoilerSpan span : ayuSpans) {
+            int start = ayuBlock.getSpanStart(span);
+            int end = ayuBlock.getSpanEnd(span);
+            if (start >= 0 && end > start && end <= sb.length()) {
+                for (Emoji.EmojiSpan e : sb.getSpans(start, end, Emoji.EmojiSpan.class)) {
+                    final Emoji.EmojiSpan captured = e;
+                    sb.setSpan(new ReplacementSpan() {
+                        @Override
+                        public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
+                            return captured.getSize(paint, text, s, e2, fm);
+                        }
+                        @Override
+                        public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
+                        }
+                    }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    sb.removeSpan(e);
+                }
+                sb.setSpan(new ForegroundColorSpan(Color.TRANSPARENT), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+        }
+        // Also make real Telegram spoiler ranges transparent so it can coexist with ayu masks without interference
+        if (block.textLayout.getText() instanceof Spanned) {
+            Spanned sp = (Spanned) block.textLayout.getText();
+            TextStyleSpan[] tgSpans = sp.getSpans(0, sp.length(), TextStyleSpan.class);
+            for (TextStyleSpan span : tgSpans) {
+                if (span.isSpoiler()) {
+                    int start = sp.getSpanStart(span);
+                    int end = sp.getSpanEnd(span);
+                    if (start >= 0 && end > start && end <= sb.length()) {
+                        sb.setSpan(new ForegroundColorSpan(Color.TRANSPARENT), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    }
+                }
+            }
+        }
+        Layout patchedLayout;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            patchedLayout = StaticLayout.Builder.obtain(sb, 0, sb.length(), block.textLayout.getPaint(), block.textLayout.getWidth())
+                    .setBreakStrategy(StaticLayout.BREAK_STRATEGY_HIGH_QUALITY)
+                    .setHyphenationFrequency(StaticLayout.HYPHENATION_FREQUENCY_NONE)
+                    .setAlignment(block.textLayout.getAlignment())
+                    .setLineSpacing(block.textLayout.getSpacingAdd(), block.textLayout.getSpacingMultiplier())
+                    .build();
+        } else {
+            patchedLayout = new StaticLayout(sb, block.textLayout.getPaint(), block.textLayout.getWidth(), block.textLayout.getAlignment(), block.textLayout.getSpacingMultiplier(), block.textLayout.getSpacingAdd(), false);
+        }
+
+        block.spoilersPatchedTextLayout.set(patchedLayout);
+    }
+
     public void generateLayout(TLRPC.User fromUser) {
         if (type != TYPE_TEXT && type != TYPE_EMOJIS && type != TYPE_STORY_MENTION || messageOwner.peer_id == null || TextUtils.isEmpty(messageText) && !isBotPendingDraft) {
             return;
@@ -8719,12 +8838,21 @@ public class MessageObject {
             linesOffset += currentBlockLinesCount;
 
             block.spoilers.clear();
+
+            block.ayuSpoilerGroups = null;
+            block.spoilersPatchedTextLayout.set(null);
             if (!isSpoilersRevealed && !spoiledLoginCode) {
                 int right = linesMaxWidthWithLeft;
                 if (block.quote) {
                     right -= AndroidUtilities.dp(32);
                 } else if (block.code) {
                     right -= AndroidUtilities.dp(15);
+                }
+
+                Spanned ayuBlock = ayuSpoilerBlockSpannable(ayuSpoilerText, block);
+                if (ayuBlock != null) {
+                    ayuBuildSpoilerGroups(block, ayuBlock, right);
+                    ayuPreBuildPatchedLayout(block, ayuBlock);
                 }
                 SpoilerEffect.addSpoilers(null, block.textLayout, -1, right, null, block.spoilers);
             }
@@ -9166,12 +9294,22 @@ public class MessageObject {
                 }
 
                 linesOffset += currentBlockLinesCount;
+                block.spoilers.clear();
+
+                block.ayuSpoilerGroups = null;
+                block.spoilersPatchedTextLayout.set(null);
                 if (messageObject != null && !messageObject.isSpoilersRevealed && !messageObject.spoiledLoginCode) {
                     int right = linesMaxWidthWithLeft;
                     if (block.quote) {
                         right -= AndroidUtilities.dp(32);
                     } else if (block.code) {
                         right -= AndroidUtilities.dp(15);
+                    }
+
+                    Spanned ayuBlock = MessageObject.ayuSpoilerBlockSpannable(messageObject.ayuSpoilerText, block);
+                    if (ayuBlock != null) {
+                        MessageObject.ayuBuildSpoilerGroups(block, ayuBlock, right);
+                        MessageObject.ayuPreBuildPatchedLayout(block, ayuBlock);
                     }
                     SpoilerEffect.addSpoilers(null, block.textLayout, -1, right, null, block.spoilers);
                 }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -791,6 +791,7 @@ public class MessageObject {
             }
         }
         isSpoilersRevealed = old.isSpoilersRevealed;
+        ayuSpoilerRevealed = old.ayuSpoilerRevealed;
         messageOwner.replyStory = old.messageOwner.replyStory;
         if (messageOwner.media != null && old.messageOwner.media != null) {
             messageOwner.media.storyItem = old.messageOwner.media.storyItem;
@@ -798,6 +799,12 @@ public class MessageObject {
         if (isSpoilersRevealed && textLayoutBlocks != null) {
             for (TextLayoutBlock block : textLayoutBlocks) {
                 block.spoilers.clear();
+            }
+        }
+        if (ayuSpoilerRevealed && textLayoutBlocks != null) {
+            for (TextLayoutBlock block : textLayoutBlocks) {
+                block.ayuSpoilerGroups = null;
+                block.ayuSpoilersPatchedTextLayout.set(null);
             }
         }
     }
@@ -8364,47 +8371,50 @@ public class MessageObject {
         }
     }
 
+    private static void suppressSelfDrawingSpans(SpannableStringBuilder sb, int start, int end) {
+        for (Emoji.EmojiSpan e : sb.getSpans(start, end, Emoji.EmojiSpan.class)) {
+            final Emoji.EmojiSpan captured = e;
+            sb.setSpan(new ReplacementSpan() {
+                @Override
+                public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
+                    return captured.getSize(paint, text, s, e2, fm);
+                }
+                @Override
+                public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
+                }
+            }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            sb.removeSpan(e);
+        }
+        for (AnimatedEmojiSpan e : sb.getSpans(start, end, AnimatedEmojiSpan.class)) {
+            final AnimatedEmojiSpan captured = e;
+            sb.setSpan(new ReplacementSpan() {
+                @Override
+                public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
+                    return captured.getSize(paint, text, s, e2, fm);
+                }
+                @Override
+                public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
+                }
+            }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            sb.removeSpan(e);
+        }
+    }
+
     public static void ayuPreBuildPatchedLayout(TextLayoutBlock block, Spanned ayuBlock) {
         if (block.ayuSpoilerGroups == null || block.ayuSpoilerGroups.isEmpty()) return;
         SpannableStringBuilder sb = new SpannableStringBuilder(block.textLayout.getText());
 
-        // make all emoji span into proper span that can be hide properly
-        // then make filter spoiler mask transparent
+        // suppress self-drawing emoji spans and make filter spoiler mask transparent
         AyuSpoilerSpan[] ayuSpans = ayuBlock.getSpans(0, ayuBlock.length(), AyuSpoilerSpan.class);
         for (AyuSpoilerSpan span : ayuSpans) {
             int start = ayuBlock.getSpanStart(span);
             int end = ayuBlock.getSpanEnd(span);
             if (start >= 0 && end > start && end <= sb.length()) {
-                for (Emoji.EmojiSpan e : sb.getSpans(start, end, Emoji.EmojiSpan.class)) {
-                    final Emoji.EmojiSpan captured = e;
-                    sb.setSpan(new ReplacementSpan() {
-                        @Override
-                        public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
-                            return captured.getSize(paint, text, s, e2, fm);
-                        }
-                        @Override
-                        public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
-                        }
-                    }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-                    sb.removeSpan(e);
-                }
-                for (AnimatedEmojiSpan e : sb.getSpans(start, end, AnimatedEmojiSpan.class)) {
-                    final AnimatedEmojiSpan captured = e;
-                    sb.setSpan(new ReplacementSpan() {
-                        @Override
-                        public int getSize(@NonNull Paint paint, CharSequence text, int s, int e2, @Nullable Paint.FontMetricsInt fm) {
-                            return captured.getSize(paint, text, s, e2, fm);
-                        }
-                        @Override
-                        public void draw(@NonNull Canvas canvas, CharSequence text, int s, int e2, float x, int top, int y, int bottom, @NonNull Paint paint) {
-                        }
-                    }, sb.getSpanStart(e), sb.getSpanEnd(e), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-                    sb.removeSpan(e);
-                }
+                suppressSelfDrawingSpans(sb, start, end);
                 sb.setSpan(new ForegroundColorSpan(Color.TRANSPARENT), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             }
         }
-        // Also make real Telegram spoiler ranges transparent so it can coexist with ayu masks without interference
+        // Also suppress self-drawing emoji inside native Telegram spoiler ranges
         if (block.textLayout.getText() instanceof Spanned) {
             Spanned sp = (Spanned) block.textLayout.getText();
             TextStyleSpan[] tgSpans = sp.getSpans(0, sp.length(), TextStyleSpan.class);
@@ -8431,7 +8441,7 @@ public class MessageObject {
             patchedLayout = new StaticLayout(sb, block.textLayout.getPaint(), block.textLayout.getWidth(), block.textLayout.getAlignment(), block.textLayout.getSpacingMultiplier(), block.textLayout.getSpacingAdd(), false);
         }
 
-        block.spoilersPatchedTextLayout.set(patchedLayout);
+        block.ayuSpoilersPatchedTextLayout.set(patchedLayout);
     }
 
     public void generateLayout(TLRPC.User fromUser) {
@@ -8856,6 +8866,7 @@ public class MessageObject {
 
             block.ayuSpoilerGroups = null;
             block.spoilersPatchedTextLayout.set(null);
+            block.ayuSpoilersPatchedTextLayout.set(null);
             boolean hasUnrevealedAyu = ayuSpoilerText != null && !ayuSpoilerRevealed;
             if ((!isSpoilersRevealed && !spoiledLoginCode) || hasUnrevealedAyu) {
                 int right = linesMaxWidthWithLeft;
@@ -9318,6 +9329,7 @@ public class MessageObject {
 
                 block.ayuSpoilerGroups = null;
                 block.spoilersPatchedTextLayout.set(null);
+                block.ayuSpoilersPatchedTextLayout.set(null);
                 boolean hasUnrevealedAyu = messageObject != null && messageObject.ayuSpoilerText != null && !messageObject.ayuSpoilerRevealed;
                 if ((messageObject != null && !messageObject.isSpoilersRevealed && !messageObject.spoiledLoginCode) || hasUnrevealedAyu) {
                     int right = linesMaxWidthWithLeft;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -1890,6 +1890,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     public List<SpoilerEffect> replySpoilers = new ArrayList<>();
     private final Stack<SpoilerEffect> replySpoilersPool = new Stack<>();
     private final Path sPath = new Path();
+    private final Path ayuClipPath = new Path();
     public boolean isBlurred;
     public BotForumHelper.BotDraftAnimationsPool draftAnimationsPool;
 
@@ -21676,7 +21677,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             // clip out before drawing emoji so they are not drawn over spoiler and break masking of message filter
             int ayuClipSave = -1;
             if (block.ayuSpoilerGroups != null && !block.ayuSpoilerGroups.isEmpty()) {
-                Path ayuClipPath = new Path();
+                ayuClipPath.rewind();
                 for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
                     for (SpoilerEffect eff : grp.second) {
                         Rect b = eff.getBounds();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -250,12 +250,14 @@ import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
 
 import me.vkryl.android.animator.BoolAnimator;
 import me.vkryl.android.animator.FactorAnimator;
 import me.vkryl.core.BitwiseUtils;
 
 import tw.nekomimi.nekogram.NekoConfig;
+import tw.nekomimi.nekogram.filters.AyuFilter;
 import tw.nekomimi.nekogram.filters.ReactionFilter;
 import tw.nekomimi.nekogram.helpers.MessageHelper;
 import tw.nekomimi.nekogram.helpers.TimeStringHelper;
@@ -4495,8 +4497,20 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     }
                     MessageObject.TextLayoutBlock block = blocks.get(i);
                     int offX = block.isRtl() ? (int) currentMessageObject.textXOffset : 0;
+                    float yOff = block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams) + block.padTop;
+
+                    if (block.ayuSpoilerGroups != null) {
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                if (eff.getBounds().contains(x - textX + offX, (int) (y - textY - yOff))) {
+                                    spoilerPressed = eff;
+                                    return true;
+                                }
+                            }
+                        }
+                    }
                     for (SpoilerEffect eff : block.spoilers) {
-                        if (eff.getBounds().contains(x - textX + offX, (int) (y - textY - block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams)))) {
+                        if (eff.getBounds().contains(x - textX + offX, (int) (y - textY - yOff))) {
                             spoilerPressed = eff;
                             return true;
                         }
@@ -4511,8 +4525,20 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     }
                     MessageObject.TextLayoutBlock block = blocks.get(i);
                     int offX = block.isRtl() ? (int) captionLayout.textXOffset : 0;
+                    float yOff = block.textYOffset(captionLayout.textLayoutBlocks, transitionParams) + block.padTop;
+
+                    if (block.ayuSpoilerGroups != null) {
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                if (eff.getBounds().contains((int) (x - captionX + offX), (int) (y - captionY - yOff))) {
+                                    spoilerPressed = eff;
+                                    return true;
+                                }
+                            }
+                        }
+                    }
                     for (SpoilerEffect eff : block.spoilers) {
-                        if (eff.getBounds().contains((int) (x - captionX + offX), (int) (y - captionY - block.textYOffset(captionLayout.textLayoutBlocks, transitionParams)))) {
+                        if (eff.getBounds().contains((int) (x - captionX + offX), (int) (y - captionY - yOff))) {
                             spoilerPressed = eff;
                             return true;
                         }
@@ -4527,8 +4553,20 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     }
                     MessageObject.TextLayoutBlock block = blocks.get(i);
                     int offX = block.isRtl() ? (int) explanationLayout.textXOffset : 0;
+                    float yOff = block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams) + block.padTop;
+
+                    if (block.ayuSpoilerGroups != null) {
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                if (eff.getBounds().contains((int) (x - lastDrawExplanationX + offX), (int) (y - lastDrawExplanationY - yOff))) {
+                                    spoilerPressed = eff;
+                                    return true;
+                                }
+                            }
+                        }
+                    }
                     for (SpoilerEffect eff : block.spoilers) {
-                        if (eff.getBounds().contains((int) (x - lastDrawExplanationX + offX), (int) (y - lastDrawExplanationY - block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams)))) {
+                        if (eff.getBounds().contains((int) (x - lastDrawExplanationX + offX), (int) (y - lastDrawExplanationY - yOff))) {
                             spoilerPressed = eff;
                             return true;
                         }
@@ -4538,27 +4576,65 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         } else if (act == MotionEvent.ACTION_UP && spoilerPressed != null) {
             playSoundEffect(SoundEffectConstants.CLICK);
 
+            // Boolean variable to indicate if we have message filter mask or not
+            // if there is message filter mask, then remove it on click not actual spoiler tag
+            final boolean isAyuMaskActive = currentMessageObject.ayuSpoilerText != null;
             sPath.rewind();
-            if (explanationLayout != null) {
-                for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
-                    for (SpoilerEffect eff : block.spoilers) {
-                        Rect b = eff.getBounds();
-                        sPath.addRect(b.left, b.top + block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams), Path.Direction.CW);
+            if (isAyuMaskActive) {
+                if (explanationLayout != null) {
+                    for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
+                        if (block.ayuSpoilerGroups == null) continue;
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                Rect b = eff.getBounds();
+                                sPath.addRect(b.left, b.top + block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams), Path.Direction.CW);
+                            }
+                        }
                     }
                 }
-            }
-            if (captionLayout != null) {
-                for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
-                    for (SpoilerEffect eff : block.spoilers) {
-                        Rect b = eff.getBounds();
-                        sPath.addRect(b.left, b.top + block.textYOffset(captionLayout.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(captionLayout.textLayoutBlocks, transitionParams), Path.Direction.CW);
+                if (captionLayout != null) {
+                    for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
+                        if (block.ayuSpoilerGroups == null) continue;
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                Rect b = eff.getBounds();
+                                sPath.addRect(b.left, b.top + block.textYOffset(captionLayout.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(captionLayout.textLayoutBlocks, transitionParams), Path.Direction.CW);
+                            }
+                        }
+                    }
+                } else if (currentMessageObject.textLayoutBlocks != null) {
+                    for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
+                        if (block.ayuSpoilerGroups == null) continue;
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                Rect b = eff.getBounds();
+                                sPath.addRect(b.left, b.top + block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams), Path.Direction.CW);
+                            }
+                        }
                     }
                 }
-            } else if (currentMessageObject.textLayoutBlocks != null) {
-                for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
-                    for (SpoilerEffect eff : block.spoilers) {
-                        Rect b = eff.getBounds();
-                        sPath.addRect(b.left, b.top + block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams), Path.Direction.CW);
+            } else {
+                if (explanationLayout != null) {
+                    for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
+                        for (SpoilerEffect eff : block.spoilers) {
+                            Rect b = eff.getBounds();
+                            sPath.addRect(b.left, b.top + block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams), Path.Direction.CW);
+                        }
+                    }
+                }
+                if (captionLayout != null) {
+                    for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
+                        for (SpoilerEffect eff : block.spoilers) {
+                            Rect b = eff.getBounds();
+                            sPath.addRect(b.left, b.top + block.textYOffset(captionLayout.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(captionLayout.textLayoutBlocks, transitionParams), Path.Direction.CW);
+                        }
+                    }
+                } else if (currentMessageObject.textLayoutBlocks != null) {
+                    for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
+                        for (SpoilerEffect eff : block.spoilers) {
+                            Rect b = eff.getBounds();
+                            sPath.addRect(b.left, b.top + block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams), b.right, b.bottom + block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams), Path.Direction.CW);
+                        }
                     }
                 }
             }
@@ -4569,43 +4645,93 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             isSpoilerRevealing = true;
             spoilerPressed.setOnRippleEndCallback(() -> post(() -> {
                 isSpoilerRevealing = false;
-                getMessageObject().isSpoilersRevealed = true;
-                if (explanationLayout != null) {
-                    for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
-                        block.spoilers.clear();
+                if (isAyuMaskActive) {
+                    currentMessageObject.ayuSpoilerRevealed = true;
+                    applyAyuFilterSpoiler(currentMessageObject, currentMessagesGroup);
+                    if (explanationLayout != null) {
+                        for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
+                            block.ayuSpoilerGroups = null;
+                        }
                     }
-                }
-                if (captionLayout != null) {
-                    for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
-                        block.spoilers.clear();
+                    if (captionLayout != null) {
+                        for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
+                            block.ayuSpoilerGroups = null;
+                        }
                     }
-                } else if (currentMessageObject.textLayoutBlocks != null) {
-                    for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
-                        block.spoilers.clear();
+                } else {
+                    currentMessageObject.isSpoilersRevealed = true;
+                    if (explanationLayout != null) {
+                        for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
+                            block.spoilers.clear();
+                        }
+                    }
+                    if (captionLayout != null) {
+                        for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
+                            block.spoilers.clear();
+                        }
+                    } else if (currentMessageObject.textLayoutBlocks != null) {
+                        for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
+                            block.spoilers.clear();
+                        }
                     }
                 }
                 invalidate();
             }));
-            if (explanationLayout != null) {
-                for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
-                    int offX = block.isRtl() ? (int) explanationLayout.textXOffset : 0;
-                    for (SpoilerEffect eff : block.spoilers) {
-                        eff.startRipple(x - lastDrawExplanationX + offX, y - block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams) - lastDrawExplanationY, rad);
+            if (isAyuMaskActive) {
+                if (explanationLayout != null) {
+                    for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
+                        if (block.ayuSpoilerGroups == null) continue;
+                        int offX = block.isRtl() ? (int) explanationLayout.textXOffset : 0;
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                eff.startRipple(x - lastDrawExplanationX + offX, y - block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams) - lastDrawExplanationY, rad);
+                            }
+                        }
                     }
                 }
-            }
-            if (captionLayout != null) {
-                for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
-                    int offX = block.isRtl() ? (int) captionLayout.textXOffset : 0;
-                    for (SpoilerEffect eff : block.spoilers) {
-                        eff.startRipple(x - captionX + offX, y - block.textYOffset(captionLayout.textLayoutBlocks, transitionParams) - captionY, rad);
+                if (captionLayout != null) {
+                    for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
+                        if (block.ayuSpoilerGroups == null) continue;
+                        int offX = block.isRtl() ? (int) captionLayout.textXOffset : 0;
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                eff.startRipple(x - captionX + offX, y - block.textYOffset(captionLayout.textLayoutBlocks, transitionParams) - captionY, rad);
+                            }
+                        }
+                    }
+                } else if (currentMessageObject.textLayoutBlocks != null) {
+                    for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
+                        if (block.ayuSpoilerGroups == null) continue;
+                        int offX = block.isRtl() ? (int) currentMessageObject.textXOffset : 0;
+                        for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                            for (SpoilerEffect eff : grp.second) {
+                                eff.startRipple(x - textX + offX, y - block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams) - textY, rad);
+                            }
+                        }
                     }
                 }
-            } else if (currentMessageObject.textLayoutBlocks != null) {
-                for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
-                    int offX = block.isRtl() ? (int) currentMessageObject.textXOffset : 0;
-                    for (SpoilerEffect eff : block.spoilers) {
-                        eff.startRipple(x - textX + offX, y - block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams) - textY, rad);
+            } else {
+                if (explanationLayout != null) {
+                    for (MessageObject.TextLayoutBlock block : explanationLayout.textLayoutBlocks) {
+                        int offX = block.isRtl() ? (int) explanationLayout.textXOffset : 0;
+                        for (SpoilerEffect eff : block.spoilers) {
+                            eff.startRipple(x - lastDrawExplanationX + offX, y - block.textYOffset(explanationLayout.textLayoutBlocks, transitionParams) - lastDrawExplanationY, rad);
+                        }
+                    }
+                }
+                if (captionLayout != null) {
+                    for (MessageObject.TextLayoutBlock block : captionLayout.textLayoutBlocks) {
+                        int offX = block.isRtl() ? (int) captionLayout.textXOffset : 0;
+                        for (SpoilerEffect eff : block.spoilers) {
+                            eff.startRipple(x - captionX + offX, y - block.textYOffset(captionLayout.textLayoutBlocks, transitionParams) - captionY, rad);
+                        }
+                    }
+                } else if (currentMessageObject.textLayoutBlocks != null) {
+                    for (MessageObject.TextLayoutBlock block : currentMessageObject.textLayoutBlocks) {
+                        int offX = block.isRtl() ? (int) currentMessageObject.textXOffset : 0;
+                        for (SpoilerEffect eff : block.spoilers) {
+                            eff.startRipple(x - textX + offX, y - block.textYOffset(currentMessageObject.textLayoutBlocks, transitionParams) - textY, rad);
+                        }
                     }
                 }
             }
@@ -6671,6 +6797,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     public MultiLayoutTypingAnimator botDraftTypingAnimator;
 
     private void setMessageContent(MessageObject messageObject, MessageObject.GroupedMessages groupedMessages, boolean bottomNear, boolean topNear, boolean firstInChat, boolean lastInChatList) {
+        applyAyuFilterSpoiler(messageObject, groupedMessages);
         if (messageObject.checkLayout() || currentPosition != null && lastHeight != AndroidUtilities.displaySize.y) {
             currentMessageObject = null;
         }
@@ -17095,7 +17222,19 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     }
 
                     if (needDrawTextDefault) {
-                        SpoilerEffect.renderWithRipple(this, invalidateSpoilersParent, blockSpoilersColor, 0, block.spoilersPatchedTextLayout, 0, block.textLayout, block.spoilers, canvas, currentPosition != null);
+                        boolean hasAyuSpoilers = block.ayuSpoilerGroups != null && !block.ayuSpoilerGroups.isEmpty();
+                        if (hasAyuSpoilers) {
+                            for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                                if (!grp.second.isEmpty()) {
+                                    SpoilerEffect.renderWithRipple(this, invalidateSpoilersParent, grp.first, 0, block.spoilersPatchedTextLayout, 0, block.textLayout, grp.second, canvas, currentPosition != null);
+                                }
+                            }
+                            if (!block.spoilers.isEmpty()) {
+                                SpoilerEffect.renderWithRipple(this, invalidateSpoilersParent, blockSpoilersColor, 0, block.spoilersPatchedTextLayout, 0, block.textLayout, block.spoilers, canvas, currentPosition != null);
+                            }
+                        } else {
+                            SpoilerEffect.renderWithRipple(this, invalidateSpoilersParent, blockSpoilersColor, 0, block.spoilersPatchedTextLayout, 0, block.textLayout, block.spoilers, canvas, currentPosition != null);
+                        }
                     }
                     Emoji.emojiDrawingYOffset = 0;
                 } catch (Exception e) {
@@ -18839,6 +18978,52 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     messagesController.putUser(currentUser, true);
                 }
             }
+        }
+    }
+
+    private void applyAyuFilterSpoiler(MessageObject msg, MessageObject.GroupedMessages group) {
+        if (msg == null) return;
+        int action = AyuFilter.getFilterAction(msg, group);
+        if (action == AyuFilter.FilterModel.ACTION_SPOILER_ALL || action == AyuFilter.FilterModel.ACTION_SPOILER_MATCH) {
+            if (msg.ayuSpoilerRevealed) {
+                msg.ayuSpoilerText = null;
+                msg.ayuMediaSpoiler = false;
+                msg.generateLayout(null); // Rebuild so real Telegram spoilers appear
+                return;
+            }
+            CharSequence original = msg.messageText;
+            if (!(original instanceof android.text.Spannable)) {
+                msg.ayuSpoilerText = null;
+                msg.ayuMediaSpoiler = false;
+                return;
+            }
+            SpannableString spoilered = new SpannableString(original);
+            if (action == AyuFilter.FilterModel.ACTION_SPOILER_ALL) { // hide whole message
+                int color = AyuFilter.getMaskColor(msg, group);
+                spoilered.setSpan(new MessageObject.AyuSpoilerSpan(color), 0, spoilered.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            } else {
+                // only hide matched parts
+                for (AyuFilter.FilterModel fm : AyuFilter.getMatchingFilterModels(msg, group)) {
+                    if (fm.pattern == null || fm.filterAction != AyuFilter.FilterModel.ACTION_SPOILER_MATCH) continue;
+                    Matcher m = fm.pattern.matcher(original);
+                    while (m.find()) {
+                        if (m.start() == m.end()) continue;
+                        spoilered.setSpan(new MessageObject.AyuSpoilerSpan(fm.spoilerColor), m.start(), m.end(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    }
+                }
+            }
+            msg.ayuSpoilerText = spoilered;
+            // only mask media if whole message is masked
+            msg.ayuMediaSpoiler = (action == AyuFilter.FilterModel.ACTION_SPOILER_ALL)
+                    && msg.messageOwner != null
+                    && msg.messageOwner.media != null;
+            msg.generateLayout(null);
+        } else {
+            if (msg.ayuSpoilerText != null) {
+                msg.ayuSpoilerText = null;
+                msg.generateLayout(null);
+            }
+            msg.ayuMediaSpoiler = false;
         }
     }
 
@@ -21488,7 +21673,21 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 collapsed = block.collapsed(transitionParams);
                 canvas.saveLayerAlpha(0, 0, width, block.height(transitionParams) - 1, 0xFF, Canvas.ALL_SAVE_FLAG);
             }
+            // clip out before drawing emoji so they are not drawn over spoiler and break masking of message filter
+            int ayuClipSave = -1;
+            if (block.ayuSpoilerGroups != null && !block.ayuSpoilerGroups.isEmpty()) {
+                Path ayuClipPath = new Path();
+                for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
+                    for (SpoilerEffect eff : grp.second) {
+                        Rect b = eff.getBounds();
+                        ayuClipPath.addRect(b.left, b.top, b.right, b.bottom, Path.Direction.CW);
+                    }
+                }
+                ayuClipSave = canvas.save();
+                canvas.clipOutPath(ayuClipPath);
+            }
             AnimatedEmojiSpan.drawAnimatedEmojis(canvas, block.textLayout, stack, 0, block.spoilers, top, bottom, drawingYOffset, alpha, getAdaptiveEmojiColorFilter(0, getThemedColor(textColorKey)));
+            if (ayuClipSave != -1) canvas.restoreToCount(ayuClipSave);
             if (block.quoteCollapse && block.height > block.collapsedHeight) {
                 if (clip == null) {
                     clip = new GradientClip();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -17227,7 +17227,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         if (hasAyuSpoilers) {
                             for (android.util.Pair<Integer, java.util.List<SpoilerEffect>> grp : block.ayuSpoilerGroups) {
                                 if (!grp.second.isEmpty()) {
-                                    SpoilerEffect.renderWithRipple(this, invalidateSpoilersParent, grp.first, 0, block.spoilersPatchedTextLayout, 0, block.textLayout, grp.second, canvas, currentPosition != null);
+                                    SpoilerEffect.renderWithRipple(this, invalidateSpoilersParent, grp.first, 0, block.ayuSpoilersPatchedTextLayout, 0, block.textLayout, grp.second, canvas, currentPosition != null);
                                 }
                             }
                             if (!block.spoilers.isEmpty()) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -48580,7 +48580,12 @@ public class ChatActivity extends BaseFragment implements
         if (!NekoConfig.ignoreBlocked.Bool()) {
             return false;
         }
-        return getMessagesController().blockePeers.indexOfKey(senderId) >= 0 || AyuFilter.isCustomFilteredPeer(senderId);
+        boolean inBlockedPeers = getMessagesController().blockePeers.indexOfKey(senderId) >= 0;
+        // return false if we are to mask blocked user messages
+        if (inBlockedPeers && xyz.nextalone.nagram.NaConfig.INSTANCE.getMaskBlockedUserMessages().Bool()) {
+            return false;
+        }
+        return inBlockedPeers || AyuFilter.isCustomFilteredPeerHidden(senderId);
     }
 
     private void updateBotforumTabsBottomMargin() {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/AyuFilter.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/AyuFilter.java
@@ -191,37 +191,37 @@ public class AyuFilter {
         return getFilterAction(msg, group) == FilterModel.ACTION_HIDE;
     }
 
-    public static int getFilterAction(MessageObject msg, MessageObject.GroupedMessages group) {
-        if (msg == null || msg.isOutOwner()) {
-            return -1;
-        }
-
+    private static int computeCustomResult(MessageObject msg) {
         int customResult = -1;
         long senderId = msg.getFromChatId();
-
         if (senderId > 0L) {
-            // mask shadow ban user messages
             if (NekoConfig.ignoreBlocked.Bool() && getCustomFilteredUsers().contains(senderId)) {
                 CustomFilteredUser cfu = getCustomFilteredUser(senderId);
-                if (cfu != null && cfu.filterAction != FilterModel.ACTION_HIDE) { // action hide is handled already
+                if (cfu != null && cfu.filterAction != FilterModel.ACTION_HIDE) {
                     customResult = cfu.filterAction;
                 }
             }
-            // Mask messages of telegram blocked users
             if (customResult == -1 && NaConfig.INSTANCE.getMaskBlockedUserMessages().Bool()) {
                 if (MessagesController.getInstance(msg.currentAccount).blockePeers.indexOfKey(senderId) >= 0) {
                     customResult = FilterModel.ACTION_SPOILER_ALL;
                 }
             }
         }
+        return customResult;
+    }
+
+    public static int getFilterAction(MessageObject msg, MessageObject.GroupedMessages group) {
+        if (msg == null || msg.isOutOwner()) {
+            return -1;
+        }
 
         if (!NaConfig.INSTANCE.getRegexFiltersEnabled().Bool()) {
-            return customResult;
+            return computeCustomResult(msg);
         }
 
         var text = getMessageText(msg, group);
         if (TextUtils.isEmpty(text)) {
-            return customResult;
+            return computeCustomResult(msg);
         }
         if (filterModels == null) {
             getRegexFilters();
@@ -231,7 +231,7 @@ public class AyuFilter {
         }
         long dialogId = msg.getDialogId();
         if (isDialogExcluded(dialogId)) {
-            return customResult;
+            return computeCustomResult(msg);
         }
 
         LruCache<Integer, Integer> dialogCache = filteredCache.computeIfAbsent(dialogId, k -> new LruCache<>(PER_DIALOG_CACHE_LIMIT));
@@ -241,26 +241,26 @@ public class AyuFilter {
             cached = dialogCache.get(msg.getId());
         }
 
+        int regexResult;
         if (cached != null) {
-            return cached;
-        }
-
-        int result = getFilterActionInternal(text, dialogId);
-
-        if (customResult != -1 && (result == -1 || customResult < result)) {
-            result = customResult;
-        }
-
-        synchronized (dialogCache) {
-            dialogCache.put(msg.getId(), result);
-            if (group != null && group.messages != null && !group.messages.isEmpty()) {
-                for (var m : group.messages) {
-                    dialogCache.put(m.getId(), result);
+            regexResult = cached;
+        } else {
+            regexResult = getFilterActionInternal(text, dialogId);
+            synchronized (dialogCache) {
+                dialogCache.put(msg.getId(), regexResult);
+                if (group != null && group.messages != null && !group.messages.isEmpty()) {
+                    for (var m : group.messages) {
+                        dialogCache.put(m.getId(), regexResult);
+                    }
                 }
             }
         }
 
-        return result;
+        int customResult = computeCustomResult(msg);
+        if (customResult != -1 && (regexResult == -1 || customResult < regexResult)) {
+            return customResult;
+        }
+        return regexResult;
     }
 
     public static List<FilterModel> getMatchingFilterModels(MessageObject msg, MessageObject.GroupedMessages group) {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/AyuFilter.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/AyuFilter.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -31,7 +32,7 @@ import xyz.nextalone.nagram.NaConfig;
 public class AyuFilter {
     private static final Object cacheLock = new Object();
     private static final int PER_DIALOG_CACHE_LIMIT = 1000;
-    private static final ConcurrentHashMap<Long, LruCache<Integer, Boolean>> filteredCache = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<Long, LruCache<Integer, Integer>> filteredCache = new ConcurrentHashMap<>();
     private static volatile ArrayList<FilterModel> filterModels;
     private static volatile ArrayList<ChatFilterEntry> chatFilterEntries;
     private static volatile HashSet<Long> excludedDialogs;
@@ -66,17 +67,27 @@ public class AyuFilter {
         return filterModels;
     }
 
-    public static void addFilter(String text, boolean caseInsensitive) {
+    public static void addFilter(String text, boolean caseInsensitive, int filterAction) {
+        addFilter(text, caseInsensitive, filterAction, 0xFFFFFFFF);
+    }
+
+    public static void addFilter(String text, boolean caseInsensitive, int filterAction, int spoilerColor) {
         var list = new ArrayList<>(getRegexFilters());
         FilterModel filterModel = new FilterModel();
         filterModel.regex = text;
         filterModel.caseInsensitive = caseInsensitive;
+        filterModel.filterAction = filterAction;
+        filterModel.spoilerColor = spoilerColor;
         filterModel.enabled = true;
         list.add(0, filterModel);
         saveFilter(list);
     }
 
-    public static void editFilter(int filterIdx, String text, boolean caseInsensitive) {
+    public static void editFilter(int filterIdx, String text, boolean caseInsensitive, int filterAction) {
+        editFilter(filterIdx, text, caseInsensitive, filterAction, 0xFFFFFFFF);
+    }
+
+    public static void editFilter(int filterIdx, String text, boolean caseInsensitive, int filterAction, int spoilerColor) {
         var list = new ArrayList<>(getRegexFilters());
         if (filterIdx < 0 || filterIdx >= list.size()) {
             return;
@@ -84,6 +95,8 @@ public class AyuFilter {
         FilterModel filterModel = list.get(filterIdx);
         filterModel.regex = text;
         filterModel.caseInsensitive = caseInsensitive;
+        filterModel.filterAction = filterAction;
+        filterModel.spoilerColor = spoilerColor;
         saveFilter(list);
     }
 
@@ -134,17 +147,19 @@ public class AyuFilter {
         }
     }
 
-    private static boolean isFilteredInternal(CharSequence text, long dialogId) {
+    private static int getFilterActionInternal(CharSequence text, long dialogId) {
+        int bestAction = -1; // -1 means no match
+
         if (chatFilterEntries != null) {
             for (var entry : chatFilterEntries) {
                 if (entry.dialogId == dialogId) {
                     if (entry.filters != null) {
-                        for (var pattern : entry.filters) {
-                            if (!pattern.enabled) {
-                                continue;
-                            }
-                            if (pattern.pattern != null && pattern.pattern.matcher(text).find()) {
-                                return true;
+                        for (var fm : entry.filters) {
+                            if (!fm.enabled) continue;
+                            if (fm.pattern != null && fm.pattern.matcher(text).find()) {
+                                if (bestAction == -1 || fm.filterAction < bestAction) {
+                                    bestAction = fm.filterAction;
+                                }
                             }
                         }
                     }
@@ -155,61 +170,86 @@ public class AyuFilter {
 
         boolean isPrivateDialog = dialogId > 0;
         if (isPrivateDialog && !NaConfig.INSTANCE.getRegexFiltersEnableInChats().Bool()) {
-            return false;
+            return bestAction;
         }
 
         if (filterModels != null) {
-            for (var pattern : filterModels) {
-                if (!pattern.enabled) {
-                    continue;
-                }
-                if (pattern.pattern != null && pattern.pattern.matcher(text).find()) {
-                    return true;
+            for (var fm : filterModels) {
+                if (!fm.enabled) continue;
+                if (fm.pattern != null && fm.pattern.matcher(text).find()) {
+                    if (bestAction == -1 || fm.filterAction < bestAction) {
+                        bestAction = fm.filterAction;
+                    }
                 }
             }
         }
 
-        return false;
+        return bestAction;
     }
 
     public static boolean isFiltered(MessageObject msg, MessageObject.GroupedMessages group) {
-        if (!NaConfig.INSTANCE.getRegexFiltersEnabled().Bool()) {
-            return false;
+        return getFilterAction(msg, group) == FilterModel.ACTION_HIDE;
+    }
+
+    public static int getFilterAction(MessageObject msg, MessageObject.GroupedMessages group) {
+        if (msg == null || msg.isOutOwner()) {
+            return -1;
         }
 
-        if (msg == null || msg.isOutOwner()) {
-            return false;
+        int customResult = -1;
+        long senderId = msg.getFromChatId();
+
+        if (senderId > 0L) {
+            // mask shadow ban user messages
+            if (NekoConfig.ignoreBlocked.Bool() && getCustomFilteredUsers().contains(senderId)) {
+                CustomFilteredUser cfu = getCustomFilteredUser(senderId);
+                if (cfu != null && cfu.filterAction != FilterModel.ACTION_HIDE) { // action hide is handled already
+                    customResult = cfu.filterAction;
+                }
+            }
+            // Mask messages of telegram blocked users
+            if (customResult == -1 && NaConfig.INSTANCE.getMaskBlockedUserMessages().Bool()) {
+                if (MessagesController.getInstance(msg.currentAccount).blockePeers.indexOfKey(senderId) >= 0) {
+                    customResult = FilterModel.ACTION_SPOILER_ALL;
+                }
+            }
+        }
+
+        if (!NaConfig.INSTANCE.getRegexFiltersEnabled().Bool()) {
+            return customResult;
         }
 
         var text = getMessageText(msg, group);
         if (TextUtils.isEmpty(text)) {
-            return false;
+            return customResult;
         }
-
         if (filterModels == null) {
             getRegexFilters();
         }
         if (chatFilterEntries == null) {
             getChatFilterEntries();
         }
-
         long dialogId = msg.getDialogId();
         if (isDialogExcluded(dialogId)) {
-            return false;
+            return customResult;
         }
 
-        LruCache<Integer, Boolean> dialogCache = filteredCache.computeIfAbsent(dialogId, k -> new LruCache<>(PER_DIALOG_CACHE_LIMIT));
-        Boolean result;
+        LruCache<Integer, Integer> dialogCache = filteredCache.computeIfAbsent(dialogId, k -> new LruCache<>(PER_DIALOG_CACHE_LIMIT));
+        Integer cached;
 
         synchronized (dialogCache) {
-            result = dialogCache.get(msg.getId());
+            cached = dialogCache.get(msg.getId());
         }
 
-        if (result != null) {
-            return result;
+        if (cached != null) {
+            return cached;
         }
 
-        result = isFilteredInternal(text, dialogId);
+        int result = getFilterActionInternal(text, dialogId);
+
+        if (customResult != -1 && (result == -1 || customResult < result)) {
+            result = customResult;
+        }
 
         synchronized (dialogCache) {
             dialogCache.put(msg.getId(), result);
@@ -221,6 +261,49 @@ public class AyuFilter {
         }
 
         return result;
+    }
+
+    public static List<FilterModel> getMatchingFilterModels(MessageObject msg, MessageObject.GroupedMessages group) {
+        List<FilterModel> matches = new ArrayList<>();
+        if (!NaConfig.INSTANCE.getRegexFiltersEnabled().Bool()) return matches;
+        if (msg == null || msg.isOutOwner()) return matches;
+
+        var text = getMessageText(msg, group);
+        if (TextUtils.isEmpty(text)) return matches;
+
+        if (filterModels == null) getRegexFilters();
+        if (chatFilterEntries == null) getChatFilterEntries();
+
+        long dialogId = msg.getDialogId();
+        if (isDialogExcluded(dialogId)) return matches;
+
+        if (chatFilterEntries != null) {
+            for (var entry : chatFilterEntries) {
+                if (entry.dialogId == dialogId) {
+                    if (entry.filters != null) {
+                        for (var fm : entry.filters) {
+                            if (fm.enabled && fm.pattern != null && fm.pattern.matcher(text).find()) {
+                                matches.add(fm);
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        boolean isPrivate = dialogId > 0;
+        if (isPrivate && !NaConfig.INSTANCE.getRegexFiltersEnableInChats().Bool()) return matches;
+
+        if (filterModels != null) {
+            for (var fm : filterModels) {
+                if (fm.enabled && fm.pattern != null && fm.pattern.matcher(text).find()) {
+                    matches.add(fm);
+                }
+            }
+        }
+
+        return matches;
     }
 
     public static ArrayList<ChatFilterEntry> getChatFilterEntries() {
@@ -274,7 +357,11 @@ public class AyuFilter {
         return new ArrayList<>();
     }
 
-    public static void addChatFilter(long dialogId, String text, boolean caseInsensitive) {
+    public static void addChatFilter(long dialogId, String text, boolean caseInsensitive, int filterAction) {
+        addChatFilter(dialogId, text, caseInsensitive, filterAction, 0xFFFFFFFF);
+    }
+
+    public static void addChatFilter(long dialogId, String text, boolean caseInsensitive, int filterAction, int spoilerColor) {
         var entries = new ArrayList<>(getChatFilterEntries());
         ChatFilterEntry target = null;
         for (var e : entries) {
@@ -292,6 +379,8 @@ public class AyuFilter {
         FilterModel filterModel = new FilterModel();
         filterModel.regex = text;
         filterModel.caseInsensitive = caseInsensitive;
+        filterModel.filterAction = filterAction;
+        filterModel.spoilerColor = spoilerColor;
         filterModel.enabled = true;
         if (target.filters == null) {
             target.filters = new ArrayList<>();
@@ -301,7 +390,11 @@ public class AyuFilter {
         saveChatFilterEntries(entries);
     }
 
-    public static void editChatFilter(long dialogId, int filterIdx, String text, boolean caseInsensitive) {
+    public static void editChatFilter(long dialogId, int filterIdx, String text, boolean caseInsensitive, int filterAction) {
+        editChatFilter(dialogId, filterIdx, text, caseInsensitive, filterAction, 0xFFFFFFFF);
+    }
+
+    public static void editChatFilter(long dialogId, int filterIdx, String text, boolean caseInsensitive, int filterAction, int spoilerColor) {
         var entries = new ArrayList<>(getChatFilterEntries());
         for (var e : entries) {
             if (e.dialogId == dialogId) {
@@ -309,11 +402,36 @@ public class AyuFilter {
                     var fm = e.filters.get(filterIdx);
                     fm.regex = text;
                     fm.caseInsensitive = caseInsensitive;
+                    fm.filterAction = filterAction;
+                    fm.spoilerColor = spoilerColor;
                     saveChatFilterEntries(entries);
                 }
                 return;
             }
         }
+    }
+
+    // Get the mask color for spoiler particle
+    public static int getMaskColor(MessageObject msg, MessageObject.GroupedMessages group) {
+        int winningAction = getFilterAction(msg, group);
+        if (winningAction == FilterModel.ACTION_HIDE) return 0xFFFFFFFF;
+        for (FilterModel fm : getMatchingFilterModels(msg, group)) {
+            if (fm.filterAction == winningAction) return fm.spoilerColor;
+        }
+        long senderId = msg.getFromChatId();
+        if (senderId > 0L) {
+            CustomFilteredUser cfu = getCustomFilteredUser(senderId);
+            if (cfu != null && cfu.filterAction == winningAction) {
+                return cfu.spoilerColor;
+            }
+
+            if (NaConfig.INSTANCE.getMaskBlockedUserMessages().Bool()) {
+                if (MessagesController.getInstance(msg.currentAccount).blockePeers.indexOfKey(senderId) >= 0) {
+                    return NaConfig.INSTANCE.getBlockedUserMaskColor().Int();
+                }
+            }
+        }
+        return 0xFFFFFFFF;
     }
 
     public static void removeChatFilter(long dialogId, int filterIdx) {
@@ -431,6 +549,32 @@ public class AyuFilter {
 
     public static boolean isCustomFilteredPeer(long peerId) {
         return NekoConfig.ignoreBlocked.Bool() && peerId > 0L && getCustomFilteredUsers().contains(peerId);
+    }
+
+    // If shadow ban is on hide message, return true (mask is not handled here)
+    public static boolean isCustomFilteredPeerHidden(long peerId) {
+        if (!NekoConfig.ignoreBlocked.Bool() || peerId <= 0L) return false;
+        if (!getCustomFilteredUsers().contains(peerId)) return false;
+        CustomFilteredUser cfu = getCustomFilteredUser(peerId);
+        return cfu == null || cfu.filterAction == FilterModel.ACTION_HIDE;
+    }
+
+    public static void setCustomFilteredUserAction(long userId, int filterAction, int spoilerColor) {
+        if (userId <= 0L) return;
+        ensureCustomFilteredUsersLoaded();
+        HashSet<Long> ids = new HashSet<>(getCustomFilteredUsers());
+        if (!ids.contains(userId)) return;
+        HashMap<Long, CustomFilteredUser> map = new HashMap<>(getCustomFilteredUsersDataMap());
+        CustomFilteredUser cfu = map.get(userId);
+        if (cfu == null) {
+            cfu = new CustomFilteredUser();
+            cfu.id = userId;
+        }
+        cfu.filterAction = filterAction;
+        cfu.spoilerColor = spoilerColor;
+        map.put(userId, cfu);
+        saveCustomFilteredUsers(ids, map);
+        invalidateFilteredCache();
     }
 
     public static void blockPeer(long dialogId) {
@@ -672,6 +816,14 @@ public class AyuFilter {
     }
 
     public static class FilterModel {
+        public static final int ACTION_HIDE = 0;
+        public static final int ACTION_SPOILER_ALL = 1;
+        public static final int ACTION_SPOILER_MATCH = 2;
+
+        @Expose
+        public int filterAction = ACTION_HIDE;
+        @Expose
+        public int spoilerColor = 0xFFFFFFFF;
         @Expose
         public String regex;
         @Expose
@@ -729,5 +881,9 @@ public class AyuFilter {
         public String username;
         @Expose
         public String displayName;
+        @Expose
+        public int filterAction = FilterModel.ACTION_HIDE;
+        @Expose
+        public int spoilerColor = 0xFFFFFFFF;
     }
 }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/RegexFilterEditActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/RegexFilterEditActivity.java
@@ -344,7 +344,7 @@ public class RegexFilterEditActivity extends BaseFragment {
                 canvas.drawCircle(getWidth() / 2f, getHeight() / 2f, r - dp(1), borderPaint);
             }
         };
-        colorSwatch.setOnClickListener(swatchView -> {
+        View.OnClickListener openColorPicker = swatchView -> {
             ColorPickerBottomSheet picker = new ColorPickerBottomSheet(context, getResourceProvider());
             picker.setPipetteDelegate(new ColorPickerBottomSheet.PipetteDelegate() {
                 public void onStartColorPipette() {}
@@ -362,7 +362,10 @@ public class RegexFilterEditActivity extends BaseFragment {
                 colorSwatch.invalidate();
             });
             picker.show();
-        });
+        };
+        colorSwatch.setOnClickListener(openColorPicker);
+        colorRowFrame.setOnClickListener(openColorPicker);
+        colorSwatch.setContentDescription(getString(R.string.RegexFiltersSpoilerColor));
         colorRowFrame.addView(colorSwatch, LayoutHelper.createFrame(32, 32, Gravity.RIGHT | Gravity.CENTER_VERTICAL, 0, 0, 12, 0));
 
         spoilerColorRow = colorRowFrame;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/RegexFilterEditActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/RegexFilterEditActivity.java
@@ -6,6 +6,10 @@ import static org.telegram.messenger.LocaleController.getString;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.drawable.ColorDrawable;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -13,6 +17,7 @@ import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -29,6 +34,7 @@ import org.telegram.ui.Cells.TextCheckCell;
 import org.telegram.ui.Components.BulletinFactory;
 import org.telegram.ui.Components.EditTextBoldCursor;
 import org.telegram.ui.Components.LayoutHelper;
+import org.telegram.ui.Components.Paint.ColorPickerBottomSheet;
 
 import java.util.ArrayList;
 import java.util.regex.Pattern;
@@ -49,6 +55,8 @@ public class RegexFilterEditActivity extends BaseFragment {
     private final boolean canSelectSharedTarget;
     private boolean caseInsensitive;
     private boolean addToSharedFilters;
+    private int filterAction; // hide, spoiler all, spoiler match
+    private int spoilerColor = 0xFFFFFFFF; // default spoiler color, white
 
     private EditTextBoldCursor editField;
     private View doneButton;
@@ -57,11 +65,15 @@ public class RegexFilterEditActivity extends BaseFragment {
 
     private TextCheckCell caseInsensitiveButtonView;
     private TextCheckCell addToSharedFiltersButtonView;
+    private TextCheckCell spoilerInsteadOfHideButtonView;
+    private TextCheckCell spoilerMatchOnlyButtonView;
+    private View spoilerColorRow;
 
     public RegexFilterEditActivity() {
         filterIdx = -1;
         filterModel = null;
         caseInsensitive = true;
+        filterAction = AyuFilter.FilterModel.ACTION_HIDE;
         targetDialogId = 0L;
         chatFilterIdx = -1;
         prefillText = null;
@@ -73,6 +85,7 @@ public class RegexFilterEditActivity extends BaseFragment {
         filterIdx = -1;
         filterModel = null;
         caseInsensitive = true;
+        filterAction = AyuFilter.FilterModel.ACTION_HIDE;
         targetDialogId = dialogId;
         chatFilterIdx = -1;
         prefillText = null;
@@ -84,6 +97,7 @@ public class RegexFilterEditActivity extends BaseFragment {
         filterIdx = -1;
         filterModel = null;
         caseInsensitive = true;
+        filterAction = AyuFilter.FilterModel.ACTION_HIDE;
         targetDialogId = dialogId;
         chatFilterIdx = -1;
         this.prefillText = prefillText;
@@ -97,6 +111,8 @@ public class RegexFilterEditActivity extends BaseFragment {
         this.chatFilterIdx = chatFilterIdx;
         this.filterModel = AyuFilter.getChatFiltersForDialog(dialogId).size() > chatFilterIdx && chatFilterIdx >= 0 ? AyuFilter.getChatFiltersForDialog(dialogId).get(chatFilterIdx) : null;
         this.caseInsensitive = this.filterModel == null || this.filterModel.caseInsensitive;
+        this.filterAction = this.filterModel != null ? this.filterModel.filterAction : AyuFilter.FilterModel.ACTION_HIDE;
+        this.spoilerColor = this.filterModel != null ? this.filterModel.spoilerColor : 0xFFFFFFFF;
         this.prefillText = null;
         this.canSelectSharedTarget = false;
         this.addToSharedFilters = false;
@@ -106,6 +122,8 @@ public class RegexFilterEditActivity extends BaseFragment {
         this.filterIdx = filterIdx; // use -1 to CREATE, not EDIT
         this.filterModel = AyuFilter.getRegexFilters().get(filterIdx);
         this.caseInsensitive = filterModel.caseInsensitive;
+        this.filterAction = filterModel.filterAction;
+        this.spoilerColor = filterModel.spoilerColor;
         this.targetDialogId = 0L;
         this.chatFilterIdx = -1;
         this.prefillText = null;
@@ -147,21 +165,23 @@ public class RegexFilterEditActivity extends BaseFragment {
                     }
 
                     // If editing a chat-specific filter, update that entry and return.
+                    int savedColor = filterAction != AyuFilter.FilterModel.ACTION_HIDE ? spoilerColor : 0xFFFFFFFF;
+
                     if (chatFilterIdx != -1 && targetDialogId != 0L) {
-                        AyuFilter.editChatFilter(targetDialogId, chatFilterIdx, text, caseInsensitive);
+                        AyuFilter.editChatFilter(targetDialogId, chatFilterIdx, text, caseInsensitive, filterAction, savedColor);
                     } else if (filterIdx != -1) {
                         // editing shared filter
-                        AyuFilter.editFilter(filterIdx, text, caseInsensitive);
+                        AyuFilter.editFilter(filterIdx, text, caseInsensitive, filterAction, savedColor);
                     } else {
                         // creating a new filter (shared or chat-scoped)
                         if (targetDialogId != 0L) {
                             if (canSelectSharedTarget && addToSharedFilters) {
-                                AyuFilter.addFilter(text, caseInsensitive);
+                                AyuFilter.addFilter(text, caseInsensitive, filterAction, savedColor);
                             } else {
-                                AyuFilter.addChatFilter(targetDialogId, text, caseInsensitive);
+                                AyuFilter.addChatFilter(targetDialogId, text, caseInsensitive, filterAction, savedColor);
                             }
                         } else {
-                            AyuFilter.addFilter(text, caseInsensitive);
+                            AyuFilter.addFilter(text, caseInsensitive, filterAction, savedColor);
                         }
                     }
 
@@ -260,6 +280,93 @@ public class RegexFilterEditActivity extends BaseFragment {
             caseInsensitive = checked;
         });
         linearLayout.addView(caseInsensitiveButtonView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT, 24, 10, 24, 0));
+
+        // Toggle to mask message instead of hiding
+        spoilerInsteadOfHideButtonView = new TextCheckCell(context);
+        spoilerInsteadOfHideButtonView.setFocusable(true);
+        spoilerInsteadOfHideButtonView.setTextAndCheck(getString(R.string.RegexFiltersSpoilerInsteadOfHide), filterAction != AyuFilter.FilterModel.ACTION_HIDE, true);
+        spoilerInsteadOfHideButtonView.setBackgroundColor(getThemedColor(Theme.key_windowBackgroundWhite));
+        spoilerInsteadOfHideButtonView.setOnClickListener((v) -> {
+            boolean checked = !spoilerInsteadOfHideButtonView.isChecked();
+            spoilerInsteadOfHideButtonView.setChecked(checked);
+            if (!checked) {
+                filterAction = AyuFilter.FilterModel.ACTION_HIDE;
+                spoilerMatchOnlyButtonView.setVisibility(View.GONE);
+                spoilerColorRow.setVisibility(View.GONE);
+            } else {
+                filterAction = spoilerMatchOnlyButtonView.isChecked()
+                        ? AyuFilter.FilterModel.ACTION_SPOILER_MATCH
+                        : AyuFilter.FilterModel.ACTION_SPOILER_ALL;
+                spoilerMatchOnlyButtonView.setVisibility(View.VISIBLE);
+                spoilerColorRow.setVisibility(View.VISIBLE);
+            }
+        });
+        linearLayout.addView(spoilerInsteadOfHideButtonView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT, 24, 10, 24, 0));
+
+        // when mask message is enabled, show a sub option to only mask matched word
+        spoilerMatchOnlyButtonView = new TextCheckCell(context);
+        spoilerMatchOnlyButtonView.setFocusable(true);
+        spoilerMatchOnlyButtonView.setTextAndCheck(getString(R.string.RegexFiltersSpoilerMatchOnly), filterAction == AyuFilter.FilterModel.ACTION_SPOILER_MATCH, true);
+        spoilerMatchOnlyButtonView.setBackgroundColor(getThemedColor(Theme.key_windowBackgroundWhite));
+        spoilerMatchOnlyButtonView.setVisibility(filterAction == AyuFilter.FilterModel.ACTION_HIDE ? View.GONE : View.VISIBLE);
+        spoilerMatchOnlyButtonView.setOnClickListener((v) -> {
+            boolean checked = !spoilerMatchOnlyButtonView.isChecked();
+            spoilerMatchOnlyButtonView.setChecked(checked);
+            filterAction = checked ? AyuFilter.FilterModel.ACTION_SPOILER_MATCH : AyuFilter.FilterModel.ACTION_SPOILER_ALL;
+        });
+        linearLayout.addView(spoilerMatchOnlyButtonView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT, 24, 10, 24, 0));
+
+        // color picker when mask message is enabled
+        FrameLayout colorRowFrame = new FrameLayout(context);
+        colorRowFrame.setBackgroundColor(getThemedColor(Theme.key_windowBackgroundWhite));
+        colorRowFrame.setVisibility(filterAction == AyuFilter.FilterModel.ACTION_HIDE ? View.GONE : View.VISIBLE);
+
+        TextView colorLabel = new TextView(context);
+        colorLabel.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 16);
+        colorLabel.setTextColor(getThemedColor(Theme.key_windowBackgroundWhiteBlackText));
+        colorLabel.setText(getString(R.string.RegexFiltersSpoilerColor));
+        colorLabel.setGravity(Gravity.CENTER_VERTICAL);
+        colorRowFrame.addView(colorLabel, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 48, Gravity.LEFT | Gravity.CENTER_VERTICAL, 0, 0, 56, 0));
+
+        View colorSwatch = new View(context) {
+            private final Paint swatchPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            private final Paint borderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            {
+                borderPaint.setStyle(Paint.Style.STROKE);
+                borderPaint.setStrokeWidth(dp(1));
+                borderPaint.setColor(0x33000000);
+            }
+            @Override
+            protected void onDraw(Canvas canvas) {
+                float r = Math.min(getWidth(), getHeight()) / 2f;
+                swatchPaint.setColor(spoilerColor);
+                canvas.drawCircle(getWidth() / 2f, getHeight() / 2f, r - dp(1), swatchPaint);
+                canvas.drawCircle(getWidth() / 2f, getHeight() / 2f, r - dp(1), borderPaint);
+            }
+        };
+        colorSwatch.setOnClickListener(swatchView -> {
+            ColorPickerBottomSheet picker = new ColorPickerBottomSheet(context, getResourceProvider());
+            picker.setPipetteDelegate(new ColorPickerBottomSheet.PipetteDelegate() {
+                public void onStartColorPipette() {}
+                public void onStopColorPipette() {}
+                public android.view.ViewGroup getContainerView() { return null; }
+                public android.view.View getSnapshotDrawingView() { return null; }
+                public void onDrawImageOverCanvas(android.graphics.Bitmap b, Canvas c) {}
+                public boolean isPipetteVisible() { return false; }
+                public boolean isPipetteAvailable() { return false; }
+                public void onColorSelected(int color) {}
+            });
+            picker.setColor(spoilerColor);
+            picker.setColorListener(color -> {
+                spoilerColor = color;
+                colorSwatch.invalidate();
+            });
+            picker.show();
+        });
+        colorRowFrame.addView(colorSwatch, LayoutHelper.createFrame(32, 32, Gravity.RIGHT | Gravity.CENTER_VERTICAL, 0, 0, 12, 0));
+
+        spoilerColorRow = colorRowFrame;
+        linearLayout.addView(colorRowFrame, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48, LocaleController.isRTL ? Gravity.RIGHT : Gravity.LEFT, 24, 0, 24, 0));
 
         return fragmentView;
     }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/RegexFiltersSettingActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/RegexFiltersSettingActivity.java
@@ -5,10 +5,13 @@ import static org.telegram.messenger.LocaleController.getString;
 import android.annotation.SuppressLint;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.OvalShape;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
@@ -31,6 +34,7 @@ import org.telegram.ui.Cells.TextCell;
 import org.telegram.ui.Cells.TextCheckCell;
 import org.telegram.ui.Cells.TextSettingsCell;
 import org.telegram.ui.Components.BulletinFactory;
+import org.telegram.ui.Components.Paint.ColorPickerBottomSheet;
 import org.telegram.ui.Components.RecyclerListView;
 import org.telegram.ui.DialogsActivity;
 
@@ -50,6 +54,8 @@ public class RegexFiltersSettingActivity extends BaseNekoSettingsActivity {
     private int filtersOptionHeaderRow;
     private int regexFiltersEnableInChatsRow;
     private int ignoreBlockedRow;
+    private int maskBlockedUserMessagesRow;
+    private int blockedUserMaskColorRow;
     private int filtersOptionDividerRow;
     private int filtersHeaderRow;
     private int sharedFiltersPageRow;
@@ -70,6 +76,8 @@ public class RegexFiltersSettingActivity extends BaseNekoSettingsActivity {
         filtersOptionHeaderRow = -1;
         regexFiltersEnableInChatsRow = -1;
         ignoreBlockedRow = -1;
+        maskBlockedUserMessagesRow = -1;
+        blockedUserMaskColorRow = -1;
         filtersOptionDividerRow = -1;
         filtersHeaderRow = -1;
         sharedFiltersPageRow = -1;
@@ -83,6 +91,10 @@ public class RegexFiltersSettingActivity extends BaseNekoSettingsActivity {
         filtersOptionHeaderRow = rowCount++;
         regexFiltersEnableInChatsRow = rowCount++;
         ignoreBlockedRow = rowCount++;
+        maskBlockedUserMessagesRow = rowCount++;
+        if (NaConfig.INSTANCE.getMaskBlockedUserMessages().Bool()) {
+            blockedUserMaskColorRow = rowCount++;
+        }
         filtersOptionDividerRow = rowCount++;
 
         filtersHeaderRow = rowCount++;
@@ -383,6 +395,19 @@ public class RegexFiltersSettingActivity extends BaseNekoSettingsActivity {
             boolean enabled = !cell.isChecked();
             cell.setChecked(enabled);
             NekoConfig.ignoreBlocked.setConfigBool(enabled);
+            NaConfig.INSTANCE.getMaskBlockedUserMessages().setConfigBool(false);
+            AyuFilter.invalidateFilteredCache();
+            refreshRows();
+        } else if (position == maskBlockedUserMessagesRow) {
+            TextCheckCell cell = (TextCheckCell) view;
+            boolean enabled = !cell.isChecked();
+            cell.setChecked(enabled);
+            NaConfig.INSTANCE.getMaskBlockedUserMessages().setConfigBool(enabled);
+            NekoConfig.ignoreBlocked.setConfigBool(enabled);
+            AyuFilter.invalidateFilteredCache();
+            refreshRows();
+        } else if (position == blockedUserMaskColorRow) {
+            showBlockedUserColorPicker();
         } else if (position == sharedFiltersPageRow) {
             presentFragment(new RegexSharedFiltersListActivity());
         } else if (position == userFiltersPageRow) {
@@ -446,6 +471,29 @@ public class RegexFiltersSettingActivity extends BaseNekoSettingsActivity {
         }
     }
 
+    private void showBlockedUserColorPicker() {
+        if (getParentActivity() == null) return;
+        int currentColor = NaConfig.INSTANCE.getBlockedUserMaskColor().Int();
+        ColorPickerBottomSheet picker = new ColorPickerBottomSheet(getParentActivity(), getResourceProvider());
+        picker.setColor(currentColor);
+        picker.setPipetteDelegate(new ColorPickerBottomSheet.PipetteDelegate() {
+            @Override public void onStartColorPipette() {}
+            @Override public void onStopColorPipette() {}
+            @Override public android.view.ViewGroup getContainerView() { return null; }
+            @Override public android.view.View getSnapshotDrawingView() { return null; }
+            @Override public void onDrawImageOverCanvas(android.graphics.Bitmap bitmap, android.graphics.Canvas canvas) {}
+            @Override public boolean isPipetteVisible() { return false; }
+            @Override public boolean isPipetteAvailable() { return false; }
+            @Override public void onColorSelected(int color) {}
+        });
+        picker.setColorListener(color -> {
+            NaConfig.INSTANCE.getBlockedUserMaskColor().setConfigInt(color);
+            AyuFilter.invalidateFilteredCache();
+            refreshRows();
+        });
+        picker.show();
+    }
+
     @Override
     protected boolean onItemLongClick(View view, int position, float x, float y) {
         return super.onItemLongClick(view, position, x, y);
@@ -498,7 +546,10 @@ public class RegexFiltersSettingActivity extends BaseNekoSettingsActivity {
                     if (position == regexFiltersEnableInChatsRow) {
                         textCheckCell.setTextAndCheck(getString(R.string.RegexFiltersEnableInChats), NaConfig.INSTANCE.getRegexFiltersEnableInChats().Bool(), true);
                     } else if (position == ignoreBlockedRow) {
-                        textCheckCell.setTextAndCheck(getString(R.string.IgnoreBlocked), NekoConfig.ignoreBlocked.Bool(), true);
+                        boolean hideActive = NekoConfig.ignoreBlocked.Bool() && !NaConfig.INSTANCE.getMaskBlockedUserMessages().Bool();
+                        textCheckCell.setTextAndCheck(getString(R.string.IgnoreBlocked), hideActive, true);
+                    } else if (position == maskBlockedUserMessagesRow) {
+                        textCheckCell.setTextAndCheck(getString(R.string.MaskBlockedUserMessages), NaConfig.INSTANCE.getMaskBlockedUserMessages().Bool(), NaConfig.INSTANCE.getMaskBlockedUserMessages().Bool());
                     }
                     break;
                 case TYPE_TEXT:
@@ -513,6 +564,20 @@ public class RegexFiltersSettingActivity extends BaseNekoSettingsActivity {
                     } else if (position == userFiltersPageRow) {
                         int count = AyuFilter.getCustomFilteredUsersList().size() + AyuFilter.getBlockedChannelsCount();
                         settingsCell.setTextAndValue(getString(R.string.ShadowBan), String.valueOf(count), false);
+                    } else if (position == blockedUserMaskColorRow) {
+                        int maskColor = NaConfig.INSTANCE.getBlockedUserMaskColor().Int();
+                        settingsCell.setTextAndValue(getString(R.string.RegexFiltersSpoilerColor), null, false);
+                        final int circleSize = AndroidUtilities.dp(20);
+                        ShapeDrawable circle = new ShapeDrawable(new OvalShape()) {
+                            @Override public int getIntrinsicWidth() { return circleSize; }
+                            @Override public int getIntrinsicHeight() { return circleSize; }
+                        };
+                        circle.getPaint().setColor(maskColor);
+                        circle.setBounds(0, 0, circleSize, circleSize);
+                        ImageView valueImg = settingsCell.getValueImageView();
+                        valueImg.clearColorFilter();
+                        valueImg.setImageDrawable(circle);
+                        valueImg.setVisibility(View.VISIBLE);
                     }
                     break;
                 case TYPE_ACCOUNT:
@@ -547,7 +612,7 @@ public class RegexFiltersSettingActivity extends BaseNekoSettingsActivity {
                 return TYPE_SHADOW;
             } else if (position == filtersHeaderRow || position == filtersOptionHeaderRow || position == chatFiltersHeaderRow) {
                 return TYPE_HEADER;
-            } else if (position == sharedFiltersPageRow || position == userFiltersPageRow) {
+            } else if (position == sharedFiltersPageRow || position == userFiltersPageRow || position == blockedUserMaskColorRow) {
                 return TYPE_SETTINGS;
             } else if (position == addChatFilterBtnRow) {
                 return TYPE_TEXT;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/ShadowBanListActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/filters/ShadowBanListActivity.java
@@ -14,6 +14,10 @@ import android.content.DialogInterface;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.OvalShape;
+import android.text.SpannableStringBuilder;
+import android.text.style.ImageSpan;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.util.TypedValue;
@@ -51,6 +55,7 @@ import org.telegram.ui.Components.EditTextBoldCursor;
 import org.telegram.ui.Components.EmptyTextProgressView;
 import org.telegram.ui.Components.ItemOptions;
 import org.telegram.ui.Components.LayoutHelper;
+import org.telegram.ui.Components.Paint.ColorPickerBottomSheet;
 import org.telegram.ui.Components.RecyclerListView;
 import org.telegram.ui.Components.ScrollSlidingTextTabStrip;
 import org.telegram.ui.ProfileActivity;
@@ -734,8 +739,22 @@ public class ShadowBanListActivity extends BaseFragment {
         return String.valueOf(userId);
     }
 
-    private String getCustomFilteredUserRowSubtitle(long userId) {
-        return String.valueOf(userId);
+    private CharSequence getCustomFilteredUserRowSubtitle(long userId) {
+        AyuFilter.CustomFilteredUser cfu = AyuFilter.getCustomFilteredUser(userId);
+        boolean isSpoiler = cfu != null && cfu.filterAction == AyuFilter.FilterModel.ACTION_SPOILER_ALL;
+        String actionLabel = isSpoiler ? getString(R.string.RegexFiltersSpoilerInsteadOfHide) : getString(R.string.Hide);
+        String text = userId + " · " + actionLabel;
+        if (!isSpoiler) return text;
+        int color = cfu.spoilerColor;
+        int size = AndroidUtilities.dp(10);
+        ShapeDrawable circle = new ShapeDrawable(new OvalShape());
+        circle.getPaint().setColor(color);
+        circle.setBounds(0, 0, size, size);
+        SpannableStringBuilder sb = new SpannableStringBuilder("● ");
+        // show mask spoiler color as bulelt
+        sb.setSpan(new ImageSpan(circle, ImageSpan.ALIGN_BOTTOM), 0, 1, android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        sb.append(text);
+        return sb;
     }
 
     private boolean cacheResolvedCustomFilteredUser(long userId, TLRPC.User user, boolean notifyRow) {
@@ -1041,7 +1060,51 @@ public class ShadowBanListActivity extends BaseFragment {
         if (getParentActivity() == null) {
             return;
         }
-        ItemOptions.makeOptions(this, view).setScrimViewBackground(new ColorDrawable(Theme.getColor(Theme.key_windowBackgroundWhite, getResourceProvider()))).add(R.drawable.msg_delete, getString(R.string.UnshadowBan), true, () -> deleteCustomFilteredUser(userId)).setMinWidth(190).show();
+        AyuFilter.CustomFilteredUser cfu = AyuFilter.getCustomFilteredUser(userId);
+        int currentAction = cfu != null ? cfu.filterAction : AyuFilter.FilterModel.ACTION_HIDE;
+        int currentColor = cfu != null ? cfu.spoilerColor : 0xFFFFFFFF;
+
+        ItemOptions.makeOptions(this, view)
+                .setScrimViewBackground(new ColorDrawable(Theme.getColor(Theme.key_windowBackgroundWhite, getResourceProvider())))
+                .add(currentAction == AyuFilter.FilterModel.ACTION_HIDE ? R.drawable.msg_check : R.drawable.msg_archive_hide,
+                        getString(R.string.Hide), false, () -> {
+                            AyuFilter.setCustomFilteredUserAction(userId, AyuFilter.FilterModel.ACTION_HIDE, currentColor);
+                            notifyCustomFilteredUserRowChanged(userId);
+                        })
+                .add(currentAction == AyuFilter.FilterModel.ACTION_SPOILER_ALL ? R.drawable.msg_check : R.drawable.msg_spoiler,
+                        getString(R.string.RegexFiltersSpoilerInsteadOfHide), false, () -> {
+                            AyuFilter.setCustomFilteredUserAction(userId, AyuFilter.FilterModel.ACTION_SPOILER_ALL, currentColor);
+                            notifyCustomFilteredUserRowChanged(userId);
+                        })
+                .add(R.drawable.msg_colors, getString(R.string.RegexFiltersSpoilerColor), false, () -> showUserColorPicker(userId))
+                .addGap()
+                .add(R.drawable.msg_delete, getString(R.string.UnshadowBan), true, () -> deleteCustomFilteredUser(userId))
+                .setMinWidth(220)
+                .show();
+    }
+
+    private void showUserColorPicker(long userId) {
+        if (getParentActivity() == null) return;
+        AyuFilter.CustomFilteredUser cfu = AyuFilter.getCustomFilteredUser(userId);
+        int currentColor = cfu != null ? cfu.spoilerColor : 0xFFFFFFFF;
+        int currentAction = cfu != null ? cfu.filterAction : AyuFilter.FilterModel.ACTION_HIDE;
+        ColorPickerBottomSheet picker = new ColorPickerBottomSheet(getParentActivity(), getResourceProvider());
+        picker.setColor(currentColor);
+        picker.setPipetteDelegate(new ColorPickerBottomSheet.PipetteDelegate() {
+            @Override public void onStartColorPipette() {}
+            @Override public void onStopColorPipette() {}
+            @Override public android.view.ViewGroup getContainerView() { return null; }
+            @Override public android.view.View getSnapshotDrawingView() { return null; }
+            @Override public void onDrawImageOverCanvas(android.graphics.Bitmap bitmap, android.graphics.Canvas canvas) {}
+            @Override public boolean isPipetteVisible() { return false; }
+            @Override public boolean isPipetteAvailable() { return false; }
+            @Override public void onColorSelected(int color) {}
+        });
+        picker.setColorListener(color -> {
+            AyuFilter.setCustomFilteredUserAction(userId, currentAction, color);
+            notifyCustomFilteredUserRowChanged(userId);
+        });
+        picker.show();
     }
 
     private void showChannelOptions(long dialogId, View view) {

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -451,7 +451,7 @@ object NaConfig {
         addConfig(
             "BlockedUserMaskColor",
             ConfigItem.configTypeInt,
-            0xFFFFFFFF.toInt()
+            0xFF888888.toInt()
         )
     val showTimeHint =
         addConfig(

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -441,6 +441,18 @@ object NaConfig {
             ConfigItem.configTypeString,
             "[]"
         )
+    val maskBlockedUserMessages =
+        addConfig(
+            "MaskBlockedUserMessages",
+            ConfigItem.configTypeBool,
+            false
+        )
+    val blockedUserMaskColor =
+        addConfig(
+            "BlockedUserMaskColor",
+            ConfigItem.configTypeInt,
+            0xFFFFFFFF.toInt()
+        )
     val showTimeHint =
         addConfig(
             "ShowTimeHint",

--- a/TMessagesProj/src/main/res/values/strings_na.xml
+++ b/TMessagesProj/src/main/res/values/strings_na.xml
@@ -90,6 +90,11 @@
     <string name="RegexFiltersChatHeader">Chat Filters</string>
     <string name="RegexFiltersEnableInChats">Enable Filters in Private Chats</string>
     <string name="RegexFiltersCaseInsensitive">Case insensitive expressions</string>
+    <string name="RegexFiltersSpoilerInsteadOfHide">Use mask(spoiler tag) instead of hiding message</string>
+    <string name="MaskBlockedUserMessages">Mask Messages from Blocked Users</string>
+    <string name="MaskBlockedUserMessagesAbout">Show messages from blocked/shadow-banned users behind a spoiler mask instead of hiding them.</string>
+    <string name="RegexFiltersSpoilerMatchOnly">Only mask matched regex</string>
+    <string name="RegexFiltersSpoilerColor">Mask particle color</string>
     <string name="RegexFiltersAdd">Add filter</string>
     <string name="RegexFiltersEdit">Edit filter</string>
     <string name="RegexFiltersAddDescription">You can use site <![CDATA[<a href="https://regex101.com">regex101.com</a>]]> to fully test your regular expression. You can also use plain text, but don\'t forget to escape brackets.</string>


### PR DESCRIPTION
## What is this?

This PR implement a masking feature for message filters, before user can hide messages completely that matches regex flters but now they can mask them with spoiler tag. Not only that but with a different spoiler tag color to identify what filter is hiding it and also know that its not normal telegram spoiler tag.

Additionally, instead of hiding blocked users messages. User can choose to mask them. Similarly for shadow ban list, they can manually change hide to mask and select a color of masking.

## Why this?

I have been trying to filter out seeing some particular kind of text but i didnt wanted to hide whole message (what if a word is mentioned in context and filter hides it). So for my use case i worked on this feature

## Note 

I am not sure how good the code quality is, i am not yet familiar with this codebase and i didn't work on much of android stuff (i did learn basic of android app in past but not much). So for understanding files and getting help with this feature implementation i used chatbot. But i still added some redundant code block (in `checkSpoilerMotionEvent` method)

Also, sorry if PR is too messy to review (i should have committed step by step)