### PR TITLE
Regression: preserve message order when scheduled to the same time

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/ScheduleTimeHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/ScheduleTimeHelper.java
@@ -170,10 +170,10 @@ public final class ScheduleTimeHelper {
     }
 
     private static long getTargetTimeFromNow(int minutes) {
-        return roundUpToScheduleMinute(System.currentTimeMillis() + (long) minutes * 60 * 1000L);
-    }
-
-    private static long roundUpToScheduleMinute(long time) {
-        return ((time + 59999L) / 60000L) * 60000L;
+        // Intentionally not rounded to the minute boundary so that two messages scheduled
+        // at the same displayed minute (e.g. both showing "10:10") retain distinct timestamps
+        // and are delivered in the order they were created. This matches official Telegram's
+        // default behavior.
+        return System.currentTimeMillis() + (long) minutes * 60 * 1000L;
     }
 }


### PR DESCRIPTION
# Repro
1. schedule message "1" to 12:34
2. schedule message "2" to 12:34

# Expected
Message "1" is first.
Message "2" is second.

# Actual
Message "2" is first.
Message "1" is second.

# Official Telegram behavior
Message "1" is first.
Message "2" is second.

# Why
This happens because of the recently added rounding to the closest minute when scheduling a message. Official Telegram is not doing that so if Message "1" is scheduled at 10:00:01 for 12:34, and if Message "2" is scheduled at 10:00:08 for 12:34, then they save their "seconds" component under the hood and this helps to preserve the relative order of the messages upon scheduling.

Rounding, instead, reverses the order and at some point start injecting messages around other messages (if the current clock second is >30 or not).