### PR TITLE
Bugfix: properly select all-between when messages were rescheduled afterwards

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -9979,11 +9979,8 @@ public class ChatActivity extends BaseFragment implements
         updateLeftBottomButton(ChatsHelper.getLeftButtonAction(this, noForwards));
     }
 
-    private boolean isSelectableBetweenMessage(MessageObject message, int begin, int end) {
+    private boolean isSelectableBetweenMessage(MessageObject message) {
         int msgId = message.getId();
-        if (msgId <= begin || msgId >= end) {
-            return false;
-        }
         int index = message.getDialogId() == dialog_id ? 0 : 1;
         if (selectedMessagesIds[index].indexOfKey(msgId) >= 0) {
             return false;
@@ -10000,14 +9997,22 @@ public class ChatActivity extends BaseFragment implements
     }
 
     public boolean canSelectBetweenMessages() {
-        int[] bounds = ChatsHelper.getSelectBetweenBounds(selectedMessagesIds);
-        if (bounds == null) {
+        if (ChatsHelper.getSelectBetweenBounds(selectedMessagesIds) == null) {
             return false;
         }
-        int begin = bounds[0];
-        int end = bounds[1];
+        int minPos = Integer.MAX_VALUE, maxPos = Integer.MIN_VALUE;
         for (int i = 0; i < messages.size(); i++) {
-            if (isSelectableBetweenMessage(messages.get(i), begin, end)) {
+            int id = messages.get(i).getId();
+            if (selectedMessagesIds[0].indexOfKey(id) >= 0 || selectedMessagesIds[1].indexOfKey(id) >= 0) {
+                if (i < minPos) minPos = i;
+                if (i > maxPos) maxPos = i;
+            }
+        }
+        if (minPos == Integer.MAX_VALUE || maxPos - minPos <= 1) {
+            return false;
+        }
+        for (int i = minPos + 1; i < maxPos; i++) {
+            if (isSelectableBetweenMessage(messages.get(i))) {
                 return true;
             }
         }
@@ -10015,28 +10020,29 @@ public class ChatActivity extends BaseFragment implements
     }
 
     public void performSelectBetweenMessages() {
-        int[] bounds = ChatsHelper.getSelectBetweenBounds(selectedMessagesIds);
-        if (bounds == null) {
+        if (ChatsHelper.getSelectBetweenBounds(selectedMessagesIds) == null) {
             return;
         }
-        int begin = bounds[0];
-        int end = bounds[1];
+        int minPos = Integer.MAX_VALUE, maxPos = Integer.MIN_VALUE;
         for (int i = 0; i < messages.size(); i++) {
+            int id = messages.get(i).getId();
+            if (selectedMessagesIds[0].indexOfKey(id) >= 0 || selectedMessagesIds[1].indexOfKey(id) >= 0) {
+                if (i < minPos) minPos = i;
+                if (i > maxPos) maxPos = i;
+            }
+        }
+        if (minPos == Integer.MAX_VALUE || maxPos - minPos <= 1) {
+            return;
+        }
+        for (int i = minPos + 1; i < maxPos; i++) {
             MessageObject message = messages.get(i);
-            if (!isSelectableBetweenMessage(message, begin, end)) {
+            if (!isSelectableBetweenMessage(message)) {
                 continue;
             }
             if (selectedMessagesIds[0].size() + selectedMessagesIds[1].size() >= 100) {
-                if (message.getId() != begin) {
-                    for (int x = 0; x < messages.size(); x++) {
-                        MessageObject msg = messages.get(x);
-                        if (msg.getId() == begin) {
-                            addToSelectedMessages(msg, false, false);
-                            addToSelectedMessages(message, true);
-                            break;
-                        }
-                    }
-                }
+                MessageObject beginMsg = messages.get(minPos);
+                addToSelectedMessages(beginMsg, false, false);
+                addToSelectedMessages(message, true);
                 break;
             }
             addToSelectedMessages(message, true);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -9996,14 +9996,22 @@ public class ChatActivity extends BaseFragment implements
         return type >= MESSAGE_TYPE_MEDIA && type != MESSAGE_TYPE_SEND_ERROR_TEXT;
     }
 
+    private boolean hasSelectedMessagesRange() {
+        return selectedMessagesIds[0].size() + selectedMessagesIds[1].size() >= 2;
+    }
+
+    private boolean isMessageSelectedForBetween(MessageObject message) {
+        int index = message.getDialogId() == dialog_id ? 0 : 1;
+        return selectedMessagesIds[index].indexOfKey(message.getId()) >= 0;
+    }
+
     public boolean canSelectBetweenMessages() {
-        if (ChatsHelper.getSelectBetweenBounds(selectedMessagesIds) == null) {
+        if (!hasSelectedMessagesRange()) {
             return false;
         }
         int minPos = Integer.MAX_VALUE, maxPos = Integer.MIN_VALUE;
         for (int i = 0; i < messages.size(); i++) {
-            int id = messages.get(i).getId();
-            if (selectedMessagesIds[0].indexOfKey(id) >= 0 || selectedMessagesIds[1].indexOfKey(id) >= 0) {
+            if (isMessageSelectedForBetween(messages.get(i))) {
                 if (i < minPos) minPos = i;
                 if (i > maxPos) maxPos = i;
             }
@@ -10020,13 +10028,12 @@ public class ChatActivity extends BaseFragment implements
     }
 
     public void performSelectBetweenMessages() {
-        if (ChatsHelper.getSelectBetweenBounds(selectedMessagesIds) == null) {
+        if (!hasSelectedMessagesRange()) {
             return;
         }
         int minPos = Integer.MAX_VALUE, maxPos = Integer.MIN_VALUE;
         for (int i = 0; i < messages.size(); i++) {
-            int id = messages.get(i).getId();
-            if (selectedMessagesIds[0].indexOfKey(id) >= 0 || selectedMessagesIds[1].indexOfKey(id) >= 0) {
+            if (isMessageSelectedForBetween(messages.get(i))) {
                 if (i < minPos) minPos = i;
                 if (i > maxPos) maxPos = i;
             }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/ChatsHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/ChatsHelper.java
@@ -448,29 +448,4 @@ public class ChatsHelper extends BaseController {
         return reqId;
     }
 
-    @Nullable
-    public static int[] getSelectBetweenBounds(SparseArray<MessageObject>[] selectedMessagesIds) {
-        int min = Integer.MAX_VALUE;
-        int max = Integer.MIN_VALUE;
-        int count = 0;
-
-        for (int a = 1; a >= 0; a--) {
-            int size = selectedMessagesIds[a].size();
-            if (size > 0) {
-                int first = selectedMessagesIds[a].keyAt(0);
-                int last = selectedMessagesIds[a].keyAt(size - 1);
-                if (first < min) min = first;
-                if (last > max) max = last;
-                count += size;
-            }
-        }
-
-        if (count < 2) {
-            return null;
-        }
-        if (min == max || (long) max - min <= 1) {
-            return null;
-        }
-        return new int[]{min, max};
-    }
 }


### PR DESCRIPTION
# Repro
1. schedule message "1" to 12:34
2. schedule message "2" to 12:35
3. schedule message "4" to 12:38
4. schedule message "3" to 12:39
   > at this point, you should have messages in the following order: 1, 2, 4, 3
6. open scheduled messages view
7. rescheduled message "3" to 12:36
   > at this point, you should have messages in the following order: 1, 2, 3, 4
8. long tap and select message "1"
9. long tap and select message "4"
10. click the "select all between" button in the action bar

# Expected
All messages are selected: 1, 2, 3, 4

# Actual
Only the following messages are selected: 1, 2, 4