### PR TITLE
Bugfix: pending reply lost when reopening chat after passcode unlock

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -9251,6 +9251,18 @@ public class ChatActivity extends BaseFragment implements
         checkInstantSearch();
         if (replyingMessageObject != null) {
             chatActivityEnterView.setReplyingMessageObject(replyingMessageObject, replyingQuote);
+            // When the view is rebuilt while a reply is pending (e.g. after the passcode lock
+            // screen calls rebuildFragments()), the fragment instance is kept but its views are
+            // recreated. setReplyingMessageObject() only restores the enter view's internal state,
+            // not the visible reply preview panel, and applyDraftMaybe() skips restoring it because
+            // replyingMessageObject is still non-null. Re-show the reply panel here.
+            if (replyingMessageObject != threadMessageObject) {
+                if (replyingQuote != null) {
+                    showFieldPanelForReplyQuote(replyingMessageObject, replyingQuote);
+                } else {
+                    showFieldPanelForReply(replyingMessageObject);
+                }
+            }
         }
 
         ViewGroup decorView = (ViewGroup) getParentActivity().getWindow().getDecorView();


### PR DESCRIPTION
## Problem
With a passcode lock enabled (and set to be locked Immediately for easier repro), the following sequence loses the pending reply reference:
1. Open a chat
2. Swipe a message to start a reply
3. Type some draft text (don't send)
4. Minimize the app using the system Home gesture
5. Reopen the app and unlock with passcode/fingerprint (given that it is configured for Immediate lockdown)

## Expected: 
pending reply + draft text. 

## Actual: 
draft text restored, reply reference lost (or at least not visible).

## Root cause
On passcode unlock, `LaunchActivity.showPasscodeActivity()` calls `ActionBarLayout.rebuildFragments(REBUILD_FLAG_REBUILD_LAST)`, which rebuilds the `ChatActivity` views via `clearViews()` while keeping the same fragment instance. `replyingMessageObject` survives, but the recreated `ChatActivityEnterView` no longer shows the reply panel. In `createView()` only `setReplyingMessageObject()` was called (internal state only), and `applyDraftMaybe()` skips restoring the panel because `replyingMessageObject != null`. So the visible reply preview is never re-shown.

## Fix
In `createView()`, when a reply is still pending after a view rebuild, re-show the visible reply panel via `showFieldPanelForReply()` / `showFieldPanelForReplyQuote()` (mirroring `fallbackFieldPanel` logic). This only runs when `replyingMessageObject != null`, so the normal chat-open path is unaffected.